### PR TITLE
Refactor: clean_model_data and na.omit to track why obs are omitted

### DIFF
--- a/R/clean_model_data.R
+++ b/R/clean_model_data.R
@@ -18,87 +18,64 @@ find_warn_missing <- function(x, type) {
 # Internal method to process data
 clean_model_data <- function(formula,
                              data,
+                             subset,
                              weights,
-                             condition_call,
-                             cluster_variable_name) {
+                             cluster) {
 
-  if (!is.null(condition_call)) {
-    r <- eval(condition_call, data)
-    data <- data[r,]
+  if(!missing(weights) && !missing(cluster) ){
+    stop("weights not yet supported with clustered standard errors")
   }
 
-  mf <- model.frame.default(formula, data = data)
+  mf <- match.call()
+  mf <- mf[c(1, match(names(formals(clean_model_data)), names(mf),0L))] #drop formals left missing
+  mf[[1]] <- quote(stats::model.frame)
+  mf[["na.action"]] <- quote(estimatr:::na.omit_detailed.data.frame) #TODO fix :::via roxygen
 
-  mf_rows_to_drop <- list(cluster = integer(0),
-                          weights = integer(0))
+  # Weights and clusters may be quoted...
+  # TODO helper function
+  if(hasName(mf, "weights") && is.character(mf[['weights']]))
+    mf[["weights"]] <- as.symbol(mf[["weights"]])
 
-  ## Parse cluster variable
-  if (!is.null(cluster_variable_name)) {
-    cluster <- eval(cluster_variable_name, data)
-    # get cluster variable from subset of data
-    if (class(cluster) %in% c('numeric', 'integer', 'factor')) {
-      # If the model frame removed observations, remove those from cluster
-      # Note: we cannot simply add the cluster variable to the formula above
-      # because then we cannot warn when there is only missingness on the
-      # cluster variable and not the actual data
-      if (length(cluster) != nrow(mf)) {
-        cluster <- cluster[row.names(data) %in% row.names(mf)]
-      }
-    } else {
-      # else cast character as factor because c++ is strongly typed
-      if (length(cluster) != nrow(mf)) {
-        cluster <- as.factor(cluster[row.names(data) %in% row.names(mf)])
-      } else {
-        cluster <- as.factor(cluster)
-      }
-    }
+  # Clusters...
+  if(hasName(mf, "cluster") && is.character(mf[['cluster']]))
+    mf[["cluster"]] <- as.symbol(mf[["cluster"]])
 
-    mf_rows_to_drop$cluster <- which(is.na(cluster))
 
-    if (length(mf_rows_to_drop$cluster) != 0) {
+  mf <- eval.parent(mf)
+
+  local({
+    na.action <- attr(mf, "na.action")
+    why_omit  <- attr(na.action, "why_omit")
+
+    # Todo generalize to all extra components
+    if(hasName(why_omit, "(cluster)")){
       warning(
-        "Some observations have missingness in the cluster variable but have not in the outcome or covariates. These observations have been dropped."
+        "Some observations have missingness in the cluster variable but not in the outcome or covariates. These observations have been dropped."
       )
     }
 
-  } else {
-    cluster <- NULL
-  }
-
-  if (!is.null(weights)) {
-
-    if (!is.null(cluster)) {
-      stop("weights not yet supported with clustered standard errors")
-    }
-
-    weights <- data[row.names(mf), deparse_var(weights)]
-
-    mf_rows_to_drop$weights <- which(is.na(weights))
-
-    if (length(mf_rows_to_drop$weights) != 0) {
+    if(hasName(why_omit, "(weights)")){
       warning(
         "Some observations have missingness in the weights variable but not in the outcome or covariates. These observations have been dropped."
       )
     }
+  })
 
-  } else {
-    weights <- NULL
+
+  ret <- list(
+    outcome=model.response(mf),
+    design_matrix=model.matrix.default(formula, data = mf)
+  )
+
+  if(!missing(weights)){
+    ret[["weights"]] <- model.extract(mf, "weights")
   }
 
-  all_rows_to_drop <- unlist(mf_rows_to_drop, F, F)
-
-  if (length(all_rows_to_drop) != 0) {
-    mf <- mf[-all_rows_to_drop, ]
-    cluster <- cluster[-all_rows_to_drop]
-    weights <- weights[-all_rows_to_drop]
+  if(!missing(cluster)){
+    ret[["cluster"]] <- model.extract(mf, "cluster")
+    if(is.character(ret[["cluster"]]))
+      ret[["cluster"]] <- as.factor(ret[["cluster"]])
   }
 
-  outcome <- model.response(mf)
-  design_matrix <- model.matrix.default(formula, data = mf)
-
-  return(list(outcome=outcome,
-              design_matrix=design_matrix,
-              cluster=cluster,
-              weights=weights))
-
+  return(ret)
 }

--- a/R/lm_lin.R
+++ b/R/lm_lin.R
@@ -19,9 +19,9 @@
 lm_lin <- function(formula,
                    data,
                    covariates,
-                   weights = NULL,
-                   subset = NULL,
-                   cluster_variable_name = NULL,
+                   weights,
+                   subset,
+                   cluster_variable_name,
                    se_type = NULL,
                    ci = TRUE,
                    alpha = .05,
@@ -47,14 +47,15 @@ lm_lin <- function(formula,
   # Get all variables for the design matrix
   full_formula <- update(formula, reformulate(c('.', cov_names), "."))
 
-  model_data <-
+  model_data <- eval.parent(substitute(
     clean_model_data(
       formula = full_formula,
       data = data,
-      condition_call = substitute(subset),
-      cluster_variable_name = substitute(cluster_variable_name),
-      weights = substitute(weights)
+      subset = subset,
+      cluster = cluster_variable_name,
+      weights = weights
     )
+  ))
 
   outcome <- model_data$outcome
   design_matrix <- model_data$design_matrix

--- a/R/lm_robust.R
+++ b/R/lm_robust.R
@@ -18,23 +18,24 @@
 #'
 lm_robust <- function(formula,
                       data,
-                      weights = NULL,
-                      subset = NULL,
-                      cluster_variable_name = NULL,
+                      weights,
+                      subset,
+                      cluster_variable_name,
                       se_type = NULL,
                       ci = TRUE,
                       alpha = .05,
                       coefficient_name = NULL,
                       return_vcov = TRUE) {
 
-  model_data <-
+  model_data <- eval.parent(substitute(
     clean_model_data(
       formula = formula,
       data = data,
-      condition_call = substitute(subset),
-      cluster_variable_name = substitute(cluster_variable_name),
-      weights = substitute(weights)
+      subset = subset,
+      cluster = cluster_variable_name,
+      weights = weights
     )
+  ))
 
   return_list <-
     lm_robust_fit(

--- a/R/na_omit_detailed.R
+++ b/R/na_omit_detailed.R
@@ -1,0 +1,72 @@
+#  Copyright (C) 1995-2013 The R Core Team
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  A copy of the GNU General Public License is available at
+#  https://www.R-project.org/Licenses/
+
+
+#' Extra logging on na.omit handler
+#'
+#' @param object a data.frame
+#' @param ... unused
+#'
+#' @return a normal \code{omit} object, with the extra attribute \code{why_omit},
+#' which contains the leftmost column containing an NA for each row that was dropped, by
+#' column name, if any were dropped.
+#'
+#' @seealso \code{\link{na.omit}}
+na.omit_detailed.data.frame <- function (object, ...)
+{
+  n <- length(object)
+  omit <- logical(nrow(object))
+  vars <- colnames(object)
+  why_omit <- list()
+  for (j in vars) {
+    x <- object[[j]]
+    if (!is.atomic(x))
+      next
+    x <- is.na(x)
+    d <- dim(x)
+    if(length(d) == 2L && d[2L] > 1){
+      for(ii in d[2L]:2L){
+        x[,ii-1L] <- x[,ii] | x[,ii-1L]
+
+      }
+      x <- x[,1L]
+    }
+
+    why_omit[[j]] <- which(x & !omit)
+    omit <- omit | x
+
+  }
+  object <- object[!omit, , drop = FALSE]
+
+  if (any(omit > 0L)) {
+    temp <- setNames(seq(omit)[omit], attr(object, "row.names")[omit])
+    attr(temp, "class") <- c("omit", "detailed")
+    attr(temp, "why_omit") <- Filter(length, why_omit)
+    attr(object, "na.action") <- temp
+  }
+  object
+}
+
+# NJF 10/18
+# Silly microbenchmark to make sure I didn't make it slower
+#df <- expand.grid(x=c(1:100, NA), y=c(1:5, NA), z=c(1:8, NA), q=c(NA,2:5))
+
+#microbenchmark(stock=na.omit(df), hack1=na.omit_detailed.data.frame(df))
+## Unit: milliseconds
+## expr      min       lq     mean   median       uq        max neval
+## stock 6.114132 6.184318 7.744881 6.232744 6.961491 101.823530   100
+## hack1 5.360638 5.480531 6.525075 5.694078 7.752104   9.323943   100
+
+

--- a/man/lm_lin.Rd
+++ b/man/lm_lin.Rd
@@ -4,9 +4,9 @@
 \alias{lm_lin}
 \title{Linear regression with the Lin (2013) covariate adjustment}
 \usage{
-lm_lin(formula, data, covariates, weights = NULL, subset = NULL,
-  cluster_variable_name = NULL, se_type = NULL, ci = TRUE, alpha = 0.05,
-  coefficient_name = NULL, return_vcov = TRUE)
+lm_lin(formula, data, covariates, weights, subset, cluster_variable_name,
+  se_type = NULL, ci = TRUE, alpha = 0.05, coefficient_name = NULL,
+  return_vcov = TRUE)
 }
 \arguments{
 \item{formula}{An object of class "formula", such as Y ~ Z. Should only have the outcome and the treatment.}

--- a/man/lm_robust.Rd
+++ b/man/lm_robust.Rd
@@ -4,9 +4,9 @@
 \alias{lm_robust}
 \title{Ordinary Least Squares with Robust Standard Errors}
 \usage{
-lm_robust(formula, data, weights = NULL, subset = NULL,
-  cluster_variable_name = NULL, se_type = NULL, ci = TRUE, alpha = 0.05,
-  coefficient_name = NULL, return_vcov = TRUE)
+lm_robust(formula, data, weights, subset, cluster_variable_name,
+  se_type = NULL, ci = TRUE, alpha = 0.05, coefficient_name = NULL,
+  return_vcov = TRUE)
 }
 \arguments{
 \item{formula}{an object of class formula, as in \code{\link{lm}}.}


### PR DESCRIPTION
@lukesonnet This is the refactor I had mentioned in #33 - instead of manually removing NA in extra components (weight, cluster, ...) one at a time, we can have `model.frame` do it. I also tried to limit the NSE to one frame of the call stack at a time, so this ended up being a bit larger diff than I usually like.

All the package tests still pass and I've verified there isn't a performance hit, but I'd appreciate any feedback if there's something I overlooked. 