### PR TITLE
Minimal working example of margins compatability

### DIFF
--- a/R/lm_robust.R
+++ b/R/lm_robust.R
@@ -59,5 +59,8 @@ lm_robust <- function(formula,
                            model_data = model_data,
                            formula = formula)
 
+
+  return_list$call <- match.call()
+
   return(return_list)
 }

--- a/tests/testthat/test_lm-robust_margins.R
+++ b/tests/testthat/test_lm-robust_margins.R
@@ -1,0 +1,30 @@
+context("lm robust margins")
+
+skip_if_not_installed("margins")
+
+
+test_that("lm robust can work with margins",{
+
+  x <- lm(mpg ~ cyl * hp + wt, data = mtcars)
+  x2 <- lm(mpg ~ cyl * hp + wt, data = mtcars)
+  expect_identical(marginal_effects(x), marginal_effects(x2))
+
+})
+
+test_that("lm robust + weights can work with margins",{
+
+  x <- lm(mpg ~ cyl * hp, data = mtcars, weights = wt)
+  x2 <- lm(mpg ~ cyl * hp, data = mtcars, weights = wt)
+  expect_identical(marginal_effects(x), marginal_effects(x2))
+
+})
+
+test_that("lm robust + cluster can work with margins",{
+
+  skip("Doesn't work yet")
+  x <- lm(mpg ~ cyl * hp + wt, data = mtcars)
+  x2 <- lm_robust(mpg ~ cyl * hp + wt, data = mtcars, clusters = am)
+  expect_identical(marginal_effects(x), marginal_effects(x2))
+
+})
+


### PR DESCRIPTION
@lukesonnet This gets us started with using `lm_robust()` models with the `margins` package by @leeper - `marginal_effects` by default finds the training data set from `model$call`, and everything else seemed to work. 

If I understand correctly, `lm_robust` should have identical coefficients as `lm`, and should only differ in standard errors / width of prediction intervals. 

Currently,  when `clusters` are specified the cluster variable is not stripped out - however `weights` do work because there is already special logic for it in `margins:::find_terms_in_model`.  