### PR TITLE
Allows output of lm_robust_fit to be tidied

### DIFF
--- a/R/lm_robust_fit.R
+++ b/R/lm_robust_fit.R
@@ -51,12 +51,12 @@ lm_robust_fit <- function(y,
 
   }
 
+  k <- ncol(X)
+
   if (is.null(colnames(X))) {
-    colnames(X) <- paste0("X", 1:ncol(X))
+    colnames(X) <- paste0("X", 1:k)
   }
   variable_names <- colnames(X)
-
-  k <- ncol(X)
 
   # Get coefficients to get df adjustments for and return
   if (is.null(coefficient_name)) {

--- a/R/lm_robust_fit.R
+++ b/R/lm_robust_fit.R
@@ -51,7 +51,11 @@ lm_robust_fit <- function(y,
 
   }
 
+  if (is.null(colnames(X))) {
+    colnames(X) <- paste0("X", 1:ncol(X))
+  }
   variable_names <- colnames(X)
+
   k <- ncol(X)
 
   # Get coefficients to get df adjustments for and return
@@ -165,6 +169,7 @@ lm_robust_fit <- function(y,
       ci_lower = ci_lower,
       ci_upper = ci_upper,
       df = dof,
+      outcome = deparse(substitute(y)),
       alpha = alpha,
       which_covs = coefficient_name,
       res_var = ifelse(fit$res_var < 0, NA, fit$res_var),

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -107,7 +107,6 @@ tidy_data_frame <- function(object, digits = NULL) {
       "df",
       "outcome"
     )
-
   return_frame <- as.data.frame(object[return_cols], stringsAsFactors = FALSE)
 }
 

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -107,6 +107,7 @@ tidy_data_frame <- function(object, digits = NULL) {
       "df",
       "outcome"
     )
+
   return_frame <- as.data.frame(object[return_cols], stringsAsFactors = FALSE)
 }
 


### PR DESCRIPTION
This closes issue #72 by adding column names to user supplied `X` if they are missing and adding `output` to the list returned by `lm_robust_fit`.

Furthermore, because we actually add the `lm_robust` class to the output of `lm_robust_fit` and not later, users can just use `tidy()` on the return of `lm_robust_fit`. This is the object hierarchy muddiness @nfultz is talking about.

So we can leave it as is, merge it in, and close #72, or we can add the class later, and instruct users they have to use `estimatr:::tidy.lm_robust()` if they want to tidy `lm_robust_fit`.