### PR TITLE
Fixed lm_lin bug dropping functions of covariates

### DIFF
--- a/R/lm_lin.R
+++ b/R/lm_lin.R
@@ -43,10 +43,15 @@ lm_lin <- function(formula,
       "The covariate formula should be a right-hand sided equation, such as '~ x1 + x2 + x3'"
     )
   }
-  cov_names <- all.vars(covariates)
 
   # Get all variables for the design matrix
-  full_formula <- update(formula, reformulate(c(".", cov_names), "."))
+  full_formula <-
+    update(
+      formula,
+      reformulate(
+        c('.', labels(cov_terms), response = '.')
+      )
+    )
 
   where <- parent.frame()
   model_data <- eval(substitute(

--- a/tests/testthat/test-lm-lin.R
+++ b/tests/testthat/test-lm-lin.R
@@ -240,4 +240,11 @@ test_that("Test LM Lin",{
     c(FALSE, FALSE, FALSE, TRUE, FALSE, TRUE)
   )
 
+  # Does lm_lin parse covariate names correctly?
+  # Previously it dropped the factor(), now properly builds factor
+  lmlo <- lm_lin(Y ~ treat, ~factor(cluster) + X1, data = dat)
+  expect_equal(
+    nrow(tidy(lmlo)),
+    22
+  )
 })


### PR DESCRIPTION
This fixes a bug where if you ran

```
lm_lin(y ~ x, ~ factor(block), data = dat)
```
the usage of `all.vars` would mean we would build the full formula of `y ~ x + block` instead of `y ~ x + factor(block)`.

Using labels on terms solves this as it keeps all of the terms rather than just the variables from the `covariates = ` argument.