### PR TITLE
Solve bug with clustered SEs

### DIFF
--- a/src/lm_robust_helper.cpp
+++ b/src/lm_robust_helper.cpp
@@ -335,8 +335,8 @@ List lm_solver(Eigen::Map<Eigen::MatrixXd>& Xfull,
        }
 
 
-       Rcout << "XtX_inv: " << std::endl << XtX_inv << std::endl;
-       Rcout << "tutX: " << std::endl << tutX << std::endl;
+       // Rcout << "XtX_inv: " << std::endl << XtX_inv << std::endl;
+       // Rcout << "tutX: " << std::endl << tutX << std::endl;
 
        Vcov_hat = XtX_inv * (tutX.transpose() * tutX) * XtX_inv;
 //

--- a/src/lm_robust_helper.cpp
+++ b/src/lm_robust_helper.cpp
@@ -243,16 +243,16 @@ List lm_solver(Eigen::Map<Eigen::MatrixXd>& Xfull,
 
        // iterate over unique cluster values
        for(int i = 1;
-           i < n;
+           i <= n;
            ++i){
 
-         if ((clusters(i) != current_cluster) | (i == (n-1))) {
-           if(i == (n-1)) {
-             len++;
-           }
-           // Rcout << current_cluster << std::endl;
-           // Rcout << start_pos << std::endl;
-           // Rcout << len << std::endl << std::endl;
+         //Rcout << "clusters(i): " << clusters(i) << std::endl;
+         if ((i == n) || (clusters(i) != current_cluster)) {
+           // Rcout << "Current cluster: " << current_cluster << std::endl;
+           // Rcout << "Starting position: " << start_pos << std::endl;
+           // Rcout << "len: " << len << std::endl << std::endl;
+           // Rcout <<  X.transpose().block(0, start_pos, r, len) << std::endl << std::endl;
+
            // Rcout <<  X.transpose().block(0, start_pos, r, len) << std::endl << std::endl;
 
            Eigen::MatrixXd H = Xoriginal.block(start_pos, 0, len, r) * XtX_inv * X.block(start_pos, 0, len, r).transpose();
@@ -316,13 +316,17 @@ List lm_solver(Eigen::Map<Eigen::MatrixXd>& Xfull,
            // Below use  t(tutX) %*% tutX to sum contributions across clusters
 
            // Rcout << "At_WX_inv: " << At_WX_inv << std::endl;
-
+           // Rcout << "ei: " << ei.segment(start_pos, len).transpose() << std::endl;
            tutX.row(j) = ei.segment(start_pos, len).transpose() * At_WX_inv;
 
-           current_cluster = clusters(i);
-           len = 1;
-           start_pos = i;
-           j++;
+           if (i < n) {
+             current_cluster = clusters(i);
+             len = 1;
+             start_pos = i;
+             j++;
+           }
+
+
          } else {
            len++;
            continue;
@@ -330,7 +334,9 @@ List lm_solver(Eigen::Map<Eigen::MatrixXd>& Xfull,
 
        }
 
-       // Rcout << "tutX: " << tutX << std::endl;
+
+       Rcout << "XtX_inv: " << std::endl << XtX_inv << std::endl;
+       Rcout << "tutX: " << std::endl << tutX << std::endl;
 
        Vcov_hat = XtX_inv * (tutX.transpose() * tutX) * XtX_inv;
 //
@@ -383,22 +389,23 @@ List lm_solver(Eigen::Map<Eigen::MatrixXd>& Xfull,
 
         // iterate over unique cluster values
         for(int i = 1;
-            i < n;
+            i <= n;
             ++i){
 
-          if ((clusters(i) != current_cluster) | (i == (n-1))) {
-            if(i == (n-1)) {
-              len++;
-            }
+          if ((i == n) || (clusters(i) != current_cluster)) {
             // Rcout << current_cluster << std::endl;
             // Rcout << start_pos << std::endl;
             // Rcout << len << std::endl << std::endl;
             // Rcout <<  X.transpose().block(0, start_pos, r, len) << std::endl << std::endl;
             // Rcout << "XteetX: " << AtA(ei.segment(start_pos, len).transpose() * X.block(start_pos, 0, len, r)) << std::endl;
             XteetX += AtA(ei.segment(start_pos, len).transpose() * X.block(start_pos, 0, len, r));
-            current_cluster = clusters(i);
-            len = 1;
-            start_pos = i;
+
+            if (i < n) {
+              current_cluster = clusters(i);
+              len = 1;
+              start_pos = i;
+            }
+
           } else {
             len++;
             continue;

--- a/src/lm_robust_helper.cpp
+++ b/src/lm_robust_helper.cpp
@@ -242,9 +242,7 @@ List lm_solver(Eigen::Map<Eigen::MatrixXd>& Xfull,
        int len = 1;
 
        // iterate over unique cluster values
-       for(int i = 1;
-           i <= n;
-           ++i){
+       for(int i = 1; i <= n; ++i){
 
          //Rcout << "clusters(i): " << clusters(i) << std::endl;
          if ((i == n) || (clusters(i) != current_cluster)) {
@@ -388,9 +386,7 @@ List lm_solver(Eigen::Map<Eigen::MatrixXd>& Xfull,
         int len = 1;
 
         // iterate over unique cluster values
-        for(int i = 1;
-            i <= n;
-            ++i){
+        for(int i = 1; i <= n; ++i){
 
           if ((i == n) || (clusters(i) != current_cluster)) {
             // Rcout << current_cluster << std::endl;

--- a/tests/testthat/test-lm-cluster.R
+++ b/tests/testthat/test-lm-cluster.R
@@ -226,3 +226,31 @@ test_that("lm works with quoted or unquoted vars and withor without factor clust
   # works with being cast in the call
   lm_robust(Y~Z, data = dat, clusters = as.factor(J))
 })
+
+test_that("Clustered SEs work with clusters of size 1", {
+  dat <- data.frame(Y = rnorm(100),
+                    X = rnorm(100),
+                    J = 1:100)
+
+  lm_cr2 <- lm_robust(Y ~ X, data = dat, clusters = J)
+  lm_stata <- lm_robust(Y ~ X, data = dat, clusters = J, se_type = "stata")
+  lmo <- lm(Y ~ X, data = dat)
+
+  bmo <-
+    BMlmSE(
+      lmo,
+      clustervar = as.factor(dat$J),
+      IK = FALSE
+    )
+
+  expect_equivalent(
+    as.matrix(tidy(lm_cr2)[, c('est', 'se', 'df')]),
+    cbind(lmo$coefficients, bmo$se, bmo$dof)
+  )
+
+  expect_equivalent(
+    as.matrix(tidy(lm_stata)[, c('est', 'se')]),
+    cbind(lmo$coefficients, bmo$se.Stata)
+  )
+
+})


### PR DESCRIPTION
If last cluster (numerically) was a singleton, then it was skipped in the estimation of cluster robust variance. This fixes that problem (and as an added benefit simplifies the algorithm).

This should be merged ASAP (lets let atleast AppVeyor check it), I think.