### PR TITLE
Fix Vignettes

### DIFF
--- a/docs/articles/getting-started.html
+++ b/docs/articles/getting-started.html
@@ -216,8 +216,8 @@ dat &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocument
 </h2>
 <p>The <code>estimatr</code> package provides <code><a href="../reference/lm_robust.html">lm_robust()</a></code> to quickly fit linear models with the most common variance estimators and degrees of freedom corrections used in social science. You can easily estimate heteroskedastic standard errors, clustered standard errors, and classical standard errors.</p>
 <p>Usage largely mimics <code>lm()</code>, although it defaults to using Eicker-Huber-White robust standard errors, specifically “HC2” standard errors. More about the exact specifications used can be found in the <a href="http://estimatr.declaredesign.org/articles/technical-notes.html#lm_robust-notes">technical notes</a> and more about the estimator can be found on its reference page: <code><a href="../reference/lm_robust.html">lm_robust()</a></code>.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">res &lt;-<span class="st"> </span><span class="kw"><a href="../reference/lm_robust.html">lm_robust</a></span>(y <span class="op">~</span><span class="st"> </span>z <span class="op">+</span><span class="st"> </span>x, <span class="dt">data =</span> dat)
-<span class="kw">summary</span>(res)
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">lmout &lt;-<span class="st"> </span><span class="kw"><a href="../reference/lm_robust.html">lm_robust</a></span>(y <span class="op">~</span><span class="st"> </span>z <span class="op">+</span><span class="st"> </span>x, <span class="dt">data =</span> dat)
+<span class="kw">summary</span>(lmout)
 <span class="co">#&gt; </span>
 <span class="co">#&gt; Call:</span>
 <span class="co">#&gt; lm_robust(formula = y ~ z + x, data = dat)</span>
@@ -233,7 +233,7 @@ dat &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocument
 <span class="co">#&gt; Multiple R-squared:  0.182 , Adjusted R-squared:  0.165 </span>
 <span class="co">#&gt; F-statistic: 10.8 on 2 and 97 DF,  p-value: 5.83e-05</span></code></pre></div>
 <p>Users can also easily get the output as a data.frame by using <code><a href="../reference/tidy.html">tidy()</a></code>.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../reference/tidy.html">tidy</a></span>(res)</code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../reference/tidy.html">tidy</a></span>(lmout)</code></pre></div>
 <table class="table">
 <thead><tr class="header">
 <th align="left">coefficient_name</th>
@@ -279,12 +279,62 @@ dat &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocument
 </tbody>
 </table>
 <p>It is straightforward to do cluster-robust inference, by passing the name of your cluster variable to the <code>clusters =</code> argument. The default variance estimator with clusters is dubbed ‘CR2’ because it is analogous to ‘HC2’ for the clustered case, and utilizes recent advances proposed by <span class="citation">Pustejovsky and Tipton (<a href="#ref-pustejovskytipton2016">2016</a>)</span> to correct hypotheses tests for small samples and work with commonly specified fixed effects and weights. Note that <code><a href="../reference/lm_robust.html">lm_robust()</a></code> is quicker if your cluster variable is a factor!</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">res_cl &lt;-<span class="st"> </span><span class="kw"><a href="../reference/lm_robust.html">lm_robust</a></span>(
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Standard estimator with clustered assignment 'z_clust'</span>
+lmout &lt;-<span class="st"> </span><span class="kw"><a href="../reference/lm_robust.html">lm_robust</a></span>(
+  y_clust <span class="op">~</span><span class="st"> </span>z_clust <span class="op">+</span><span class="st"> </span>x,
+  <span class="dt">data =</span> dat
+)</code></pre></div>
+<table class="table">
+<thead><tr class="header">
+<th align="left">coefficient_name</th>
+<th align="right">coefficients</th>
+<th align="right">se</th>
+<th align="right">p</th>
+<th align="right">ci_lower</th>
+<th align="right">ci_upper</th>
+<th align="right">df</th>
+<th align="left">outcome</th>
+</tr></thead>
+<tbody>
+<tr class="odd">
+<td align="left">(Intercept)</td>
+<td align="right">-0.48</td>
+<td align="right">0.21</td>
+<td align="right">0.02</td>
+<td align="right">-0.89</td>
+<td align="right">-0.07</td>
+<td align="right">97</td>
+<td align="left">y_clust</td>
+</tr>
+<tr class="even">
+<td align="left">z_clust</td>
+<td align="right">0.81</td>
+<td align="right">0.18</td>
+<td align="right">0.00</td>
+<td align="right">0.46</td>
+<td align="right">1.17</td>
+<td align="right">97</td>
+<td align="left">y_clust</td>
+</tr>
+<tr class="odd">
+<td align="left">x</td>
+<td align="right">1.43</td>
+<td align="right">0.29</td>
+<td align="right">0.00</td>
+<td align="right">0.86</td>
+<td align="right">2.00</td>
+<td align="right">97</td>
+<td align="left">y_clust</td>
+</tr>
+</tbody>
+</table>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># With clustered standard errors</span>
+lmout_cl &lt;-<span class="st"> </span><span class="kw"><a href="../reference/lm_robust.html">lm_robust</a></span>(
   y_clust <span class="op">~</span><span class="st"> </span>z_clust <span class="op">+</span><span class="st"> </span>x,
   <span class="dt">data =</span> dat,
   <span class="dt">clusters =</span> clust
 )
-<span class="kw"><a href="../reference/tidy.html">tidy</a></span>(res_cl)</code></pre></div>
+<span class="kw"><a href="../reference/tidy.html">tidy</a></span>(lmout_cl)</code></pre></div>
 <table class="table">
 <thead><tr class="header">
 <th align="left">coefficient_name</th>
@@ -330,13 +380,13 @@ dat &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocument
 </tbody>
 </table>
 <p>Researchers can also replicate Stata’s standard errors by using the <code>se_type =</code> argument both with and without clusters:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">res_stata &lt;-<span class="st"> </span><span class="kw"><a href="../reference/lm_robust.html">lm_robust</a></span>(
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">lmout_stata &lt;-<span class="st"> </span><span class="kw"><a href="../reference/lm_robust.html">lm_robust</a></span>(
   y_clust <span class="op">~</span><span class="st"> </span>z_clust <span class="op">+</span><span class="st"> </span>x,
   <span class="dt">data =</span> dat,
   <span class="dt">clusters =</span> clust,
   <span class="dt">se_type =</span> <span class="st">"stata"</span>
 )
-<span class="kw"><a href="../reference/tidy.html">tidy</a></span>(res_stata)</code></pre></div>
+<span class="kw"><a href="../reference/tidy.html">tidy</a></span>(lmout_stata)</code></pre></div>
 <table class="table">
 <thead><tr class="header">
 <th align="left">coefficient_name</th>
@@ -384,13 +434,13 @@ dat &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocument
 <p>Furthermore, users can take advantage of the <a href="https://github.com/leeper/margins"><code>margins</code></a> package to get marginal effects, average marginal effects and their standard errors, and more.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">library</span>(margins)
 
-res_int &lt;-<span class="st"> </span><span class="kw"><a href="../reference/lm_robust.html">lm_robust</a></span>(y <span class="op">~</span><span class="st"> </span>x <span class="op">*</span><span class="st"> </span>z, <span class="dt">data =</span> dat)
-mar_int &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/margins/topics/margins">margins</a></span>(res_int, <span class="dt">vce =</span> <span class="st">"delta"</span>)
+lmout_int &lt;-<span class="st"> </span><span class="kw"><a href="../reference/lm_robust.html">lm_robust</a></span>(y <span class="op">~</span><span class="st"> </span>x <span class="op">*</span><span class="st"> </span>z, <span class="dt">data =</span> dat)
+mar_int &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/margins/topics/margins">margins</a></span>(lmout_int, <span class="dt">vce =</span> <span class="st">"delta"</span>)
 <span class="kw">summary</span>(mar_int)
 <span class="co">#&gt;  factor    AME     SE      z      p   lower  upper</span>
 <span class="co">#&gt;       x 1.4319 0.2894 4.9468 0.0000  0.8645 1.9992</span>
 <span class="co">#&gt;       z 0.2355 0.1864 1.2633 0.2065 -0.1298 0.6008</span></code></pre></div>
-<p>Users who want their regression output in LaTeX or HTML can use the <a href="https://github.com/leifeld/texreg"><code>texreg</code></a> package, which we extend here to work with our linear regression estimators.</p>
+<p>Users who want their regression output in LaTeX or HTML can use the <a href="https://github.com/leifeld/texreg"><code>texreg</code></a> package, which we extend for the output of both the <code><a href="../reference/lm_robust.html">lm_robust()</a></code> and <code><a href="../reference/lm_lin.html">lm_lin()</a></code> functions.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">library</span>(texreg)
 
 tex_int &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/texreg/topics/extract">extract</a></span>(res_int)
@@ -402,12 +452,12 @@ tex_int &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocu
 </h2>
 <p>Adjusting for pre-treatment covariates when using regression to estimate treatment effects is common practice across scientific disciplines. However, <span class="citation">Freedman (<a href="#ref-freedman2008">2008</a>)</span> demonstrated that pre-treatment covariate adjustment biases estimates of average treatment effects. In response, <span class="citation">Lin (<a href="#ref-lin2013">2013</a>)</span> proposed an alternative estimator that would reduce this bias and improve precision. <span class="citation">Lin (<a href="#ref-lin2013">2013</a>)</span> proposes centering all pre-treatment covariates, interacting them with the treatment variable, and regressing the outcome on the treatment, the centered pre-treatment covariates, and all of the interaction terms. This can require a non-trivial amount of data pre-processing.</p>
 <p>To facilitate this, we provide a wrapper that processes the data and estimates the model. We dub this estimator the Lin estimator and it can be accessed using <code><a href="../reference/lm_lin.html">lm_lin()</a></code>. This function is a wrapper for <code><a href="../reference/lm_robust.html">lm_robust()</a></code>, and all arguments that work for <code><a href="../reference/lm_robust.html">lm_robust()</a></code> work here. The only difference is in the second argument <code>covariates</code>, where one specifies a right-sided formula with all of your pre-treatment covariates. Below is an example, and more can be seen on the function reference page <a href="#lm_lin"><code>lm_lin</code></a> and some formal notation can be seen in the <a href="http://estimatr.declaredesign.org/articles/technical-notes.html#lm_lin-notes">technical notes</a>.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">res_lin &lt;-<span class="st"> </span><span class="kw"><a href="../reference/lm_lin.html">lm_lin</a></span>(
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">lml_out &lt;-<span class="st"> </span><span class="kw"><a href="../reference/lm_lin.html">lm_lin</a></span>(
   y <span class="op">~</span><span class="st"> </span>z,
   <span class="dt">covariates =</span> <span class="op">~</span><span class="st"> </span>x,
   <span class="dt">data =</span> dat
 )
-<span class="kw"><a href="../reference/tidy.html">tidy</a></span>(res_lin)</code></pre></div>
+<span class="kw"><a href="../reference/tidy.html">tidy</a></span>(lml_out)</code></pre></div>
 <table class="table">
 <thead><tr class="header">
 <th align="left">coefficient_name</th>
@@ -468,13 +518,13 @@ tex_int &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocu
 <h2 class="hasAnchor">
 <a href="#difference_in_means" class="anchor"></a><code>difference_in_means</code>
 </h2>
-<p>While estimating differences in means may seem straightforward, we provide a function that appropriately adjusts estimates for experimental design. We provide support for unit-randomized, cluster-randomized, block-randomized, matched-pair randomized, and matched-pair clustered designs. Usage is similar to usage in regression functions. More examples can be seen on the function reference page, <code><a href="../reference/difference_in_means.html">difference_in_means()</a></code>, and the actual estimators used can be found in the <a href="articles/technical-notes.html#lm_robust-notes">technical notes</a>.</p>
+<p>While estimating differences in means may seem straightforward, it can become more complicated in designs with blocks or clusters. In these cases, estimators need to average over within-block effects and estimates of variance have to appropriately adjust for features of a design. We provide support for unit-randomized, cluster-randomized, block-randomized, matched-pair randomized, and matched-pair clustered designs. Usage is similar to usage in regression functions. More examples can be seen on the function reference page, <code><a href="../reference/difference_in_means.html">difference_in_means()</a></code>, and the actual estimators used can be found in the <a href="articles/technical-notes.html#lm_robust-notes">technical notes</a>.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Simple version</span>
-res_dim &lt;-<span class="st"> </span><span class="kw"><a href="../reference/difference_in_means.html">difference_in_means</a></span>(
+dim_out &lt;-<span class="st"> </span><span class="kw"><a href="../reference/difference_in_means.html">difference_in_means</a></span>(
   y <span class="op">~</span><span class="st"> </span>z,
   <span class="dt">data =</span> dat
 )
-<span class="kw"><a href="../reference/tidy.html">tidy</a></span>(res_dim)</code></pre></div>
+<span class="kw"><a href="../reference/tidy.html">tidy</a></span>(dim_out)</code></pre></div>
 <table class="table">
 <thead><tr class="header">
 <th align="left">coefficient_name</th>
@@ -498,11 +548,12 @@ res_dim &lt;-<span class="st"> </span><span class="kw"><a href="../reference/dif
 </tr></tbody>
 </table>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Clustered version</span>
-res_dim_cl &lt;-<span class="st"> </span><span class="kw"><a href="../reference/difference_in_means.html">difference_in_means</a></span>(
+dim_out_cl &lt;-<span class="st"> </span><span class="kw"><a href="../reference/difference_in_means.html">difference_in_means</a></span>(
   y_clust <span class="op">~</span><span class="st"> </span>z_clust,
   <span class="dt">data =</span> dat,
   <span class="dt">clusters =</span> clust
-)</code></pre></div>
+)
+<span class="kw"><a href="../reference/tidy.html">tidy</a></span>(dim_out_cl)</code></pre></div>
 <table class="table">
 <thead><tr class="header">
 <th align="left">coefficient_name</th>
@@ -527,8 +578,8 @@ res_dim_cl &lt;-<span class="st"> </span><span class="kw"><a href="../reference/
 </table>
 <p>You can check which design was learned and which kind of estimator used by examining the <code>design</code> in the output.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">data</span>(sleep)
-res_mps &lt;-<span class="st"> </span><span class="kw"><a href="../reference/difference_in_means.html">difference_in_means</a></span>(extra <span class="op">~</span><span class="st"> </span>group, <span class="dt">data =</span> sleep, <span class="dt">blocks =</span> ID)
-res_mps<span class="op">$</span>design
+dim_mps &lt;-<span class="st"> </span><span class="kw"><a href="../reference/difference_in_means.html">difference_in_means</a></span>(extra <span class="op">~</span><span class="st"> </span>group, <span class="dt">data =</span> sleep, <span class="dt">blocks =</span> ID)
+dim_mps<span class="op">$</span>design
 <span class="co">#&gt; [1] "Matched-pair"</span></code></pre></div>
 </div>
 <div id="horvitz_thompson" class="section level2">

--- a/docs/articles/technical-notes.html
+++ b/docs/articles/technical-notes.html
@@ -116,17 +116,18 @@
 <h3 class="hasAnchor">
 <a href="#coefficient-estimates" class="anchor"></a>Coefficient estimates</h3>
 <p><span class="math display">\[
-\widehat{\beta} ={({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}{\mathbf{X}}^{\top}{\mathbf{y}}\]</span></p>
-<p>Our algorithm solves the least squares problem using a rank-revealing column-pivoting QR factorization that eliminates the need to invert <span class="math inline">\({({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}\)</span> explicitly and behaves much like the default <code>lm</code> function in R. However, when <span class="math inline">\({\mathbf{X}}\)</span> is rank deficient, there are certain conditions under which the QR factorization algorithm we use, from the Eigen C++ library, drops different coefficients from the output than the default <code>lm</code> function. In general, users should avoid specifing models with rank-deficiencies. In fact, if users are certain their data are not rank deficient, they can improve the speed of <code>lm_robust</code> by setting <code>try_cholesky = TRUE</code>. This replaces the QR factorization with a Cholesky factorization that is only guaranteed to work <span class="math inline">\({\mathbf{X}}\)</span> is of full rank.</p>
+\widehat{\beta} =(\mathbf{X}^{\top}\mathbf{X})^{-1}\mathbf{X}^{\top}\mathbf{y}
+\]</span></p>
+<p>Our algorithm solves the least squares problem using a rank-revealing column-pivoting QR factorization that eliminates the need to invert <span class="math inline">\((\mathbf{X}^{\top}\mathbf{X})^{-1}\)</span> explicitly and behaves much like the default <code>lm</code> function in R. However, when <span class="math inline">\(\mathbf{X}\)</span> is rank deficient, there are certain conditions under which the QR factorization algorithm we use, from the Eigen C++ library, drops different coefficients from the output than the default <code>lm</code> function. In general, users should avoid specifing models with rank-deficiencies. In fact, if users are certain their data are not rank deficient, they can improve the speed of <code>lm_robust</code> by setting <code>try_cholesky = TRUE</code>. This replaces the QR factorization with a Cholesky factorization that is only guaranteed to work <span class="math inline">\(\mathbf{X}\)</span> is of full rank.</p>
 <div id="weights" class="section level4">
 <h4 class="hasAnchor">
 <a href="#weights" class="anchor"></a>Weights</h4>
-<p>If weights are included, we transform the data as below and then proceed as normal, following advice from <span class="citation">Romano and Wolf (<a href="#ref-romanowolf2017">2017</a>)</span> that this weighted estimator has attractive properties. We do so by first scaling all of the weights so that they sum to one. Then we multiply each row of the design matrix <span class="math inline">\({\mathbf{X}}\)</span> by the square root each unit’s weight, <span class="math inline">\(\mathbf{x}_i \sqrt{w_i}\)</span>, and then do the same to the outcome, <span class="math inline">\(\mathbf{y}_i \sqrt{w_i}\)</span>. This results in our coefficients being estimated as follows, where <span class="math inline">\({\mathbf{W}}\)</span> is a diagonal matrix with the scaled weights on the diagonal.</p>
+<p>If weights are included, we transform the data as below and then proceed as normal, following advice from <span class="citation">Romano and Wolf (<a href="#ref-romanowolf2017">2017</a>)</span> that this weighted estimator has attractive properties. We do so by first scaling all of the weights so that they sum to one. Then we multiply each row of the design matrix <span class="math inline">\(\mathbf{X}\)</span> by the square root each unit’s weight, <span class="math inline">\(\mathbf{x}_i \sqrt{w_i}\)</span>, and then do the same to the outcome, <span class="math inline">\(\mathbf{y}_i \sqrt{w_i}\)</span>. This results in our coefficients being estimated as follows, where <span class="math inline">\(\mathbf{W}\)</span> is a diagonal matrix with the scaled weights on the diagonal.</p>
 <p>Weighted: <span class="math display">\[
-\widehat{\beta} ={({\mathbf{X}}^{\top}{\mathbf{W}}{\mathbf{X}})^{-1}}{\mathbf{X}}^{\top}{\mathbf{W}}{\mathbf{y}}\]</span></p>
-<p>The transformed data are then used in the analysis below, where <span class="math inline">\({({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}\)</span> is now <span class="math inline">\({({\mathbf{X}}^{\top}{\mathbf{W}}{\mathbf{X}})^{-1}}\)</span> and <span class="math inline">\({\mathbf{X}}\)</span> is now <span class="math inline">\({\mathbf{X}}\mathrm{sqrt}[W]\)</span>, where <span class="math inline">\(\mathrm{sqrt}[.]\)</span> is an operator that applies a square root to the coefficients of some matrix.</p>
+\widehat{\beta} =(\mathbf{X}^{\top}\mathbf{W}\mathbf{X})^{-1}\mathbf{X}^{\top}\mathbf{W}\mathbf{y}
+\]</span></p>
+<p>The transformed data are then used in the analysis below, where <span class="math inline">\((\mathbf{X}^{\top}\mathbf{X})^{-1}\)</span> is now <span class="math inline">\((\mathbf{X}^{\top}\mathbf{W}\mathbf{X})^{-1}\)</span> and <span class="math inline">\(\mathbf{X}\)</span> is now <span class="math inline">\(\mathbf{X} \mathrm{sqrt}[W]\)</span>, where <span class="math inline">\(\mathrm{sqrt}[.]\)</span> is an operator that applies a square root to the coefficients of some matrix.</p>
 <p>We should note that this transformation yields the same standard errors as specifying weights using <code>aweight</code> in Stata for the “classical”, “HC0”, and “HC1” (“stata”) variance estimators. Furthermore, in the clustered case, our weighted estimator for the “stata” cluster-robust variance also matches Stata. Thus Stata’s main robust standard error estimators, “HC1” and their clustered estimator, match our package when weights are applied. Nonetheless, Stata uses a slightly different Hat matrix and thus “HC2” and “HC3” estimates in Stata when weights are specified may differ from our estimates.</p>
-<p>```</p>
 </div>
 </div>
 <div id="variance" class="section level3">
@@ -146,20 +147,20 @@
 </colgroup>
 <thead><tr class="header">
 <th><code>se_type =</code></th>
-<th>Variance Estimator (<span class="math inline">\(\widehat{{\mathbb{V}}}[\widehat{\beta}]\)</span>)</th>
+<th>Variance Estimator (<span class="math inline">\(\widehat{\mathbb{V}}[\widehat{\beta}]\)</span>)</th>
 <th>Degrees of Freedom</th>
 <th>Notes</th>
 </tr></thead>
 <tbody>
 <tr class="odd">
 <td><code>"classical"</code></td>
-<td><span class="math inline">\(\frac{{\mathbf{e}}^\top{\mathbf{e}}}{N-K} {({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}\)</span></td>
+<td><span class="math inline">\(\frac{\mathbf{e}^\top\mathbf{e}}{N-K} (\mathbf{X}^{\top}\mathbf{X})^{-1}\)</span></td>
 <td>N - K</td>
 <td></td>
 </tr>
 <tr class="even">
 <td><code>"HC0"</code></td>
-<td><span class="math inline">\({({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}{\mathbf{X}}^{\top}\mathrm{diag}\left[e_i^2\right]{\mathbf{X}}{({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}\)</span></td>
+<td><span class="math inline">\((\mathbf{X}^{\top}\mathbf{X})^{-1}\mathbf{X}^{\top}\mathrm{diag}\left[e_i^2\right]\mathbf{X}(\mathbf{X}^{\top}\mathbf{X})^{-1}\)</span></td>
 <td>N - K</td>
 <td></td>
 </tr>
@@ -167,20 +168,20 @@
 <td>
 <code>"HC1"</code>, <code>"stata"</code>
 </td>
-<td><span class="math inline">\(\frac{N}{N-K}{({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}{\mathbf{X}}^{\top}\mathrm{diag}\left[e_i^2\right]{\mathbf{X}}{({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}\)</span></td>
+<td><span class="math inline">\(\frac{N}{N-K}(\mathbf{X}^{\top}\mathbf{X})^{-1}\mathbf{X}^{\top}\mathrm{diag}\left[e_i^2\right]\mathbf{X}(\mathbf{X}^{\top}\mathbf{X})^{-1}\)</span></td>
 <td>N - K</td>
 <td>Often called the Eicker-Huber-White variance (or similar)</td>
 </tr>
 <tr class="even">
 <td>
 <code>"HC2"</code> (default)</td>
-<td><span class="math inline">\({({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}{\mathbf{X}}^{\top}\mathrm{diag}\left[\frac{e_i^2}{1-h_{ii}}\right]{\mathbf{X}}{({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}\)</span></td>
+<td><span class="math inline">\((\mathbf{X}^{\top}\mathbf{X})^{-1}\mathbf{X}^{\top}\mathrm{diag}\left[\frac{e_i^2}{1-h_{ii}}\right]\mathbf{X}(\mathbf{X}^{\top}\mathbf{X})^{-1}\)</span></td>
 <td>N - K</td>
 <td></td>
 </tr>
 <tr class="odd">
 <td><code>"HC3"</code></td>
-<td><span class="math inline">\({({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}{\mathbf{X}}{\top}\mathrm{diag}\left[\frac{e_i^2}{(1-h_{ii})^2}\right]{\mathbf{X}}{({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}\)</span></td>
+<td><span class="math inline">\((\mathbf{X}^{\top}\mathbf{X})^{-1}\mathbf{X}{\top}\mathrm{diag}\left[\frac{e_i^2}{(1-h_{ii})^2}\right]\mathbf{X}(\mathbf{X}^{\top}\mathbf{X})^{-1}\)</span></td>
 <td>N - K</td>
 <td></td>
 </tr>
@@ -188,9 +189,9 @@
 </table>
 <ul>
 <li>
-<span class="math inline">\({\mathbf{x}}_i\)</span> is the <span class="math inline">\(i\)</span>th row of <span class="math inline">\({\mathbf{X}}\)</span>.</li>
-<li><span class="math inline">\(h_{ii} = {\mathbf{x}}_i{({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}{\mathbf{x}}^{\top}_i\)</span></li>
-<li><span class="math inline">\(e_i = y_i - {\mathbf{x}}_i\widehat{\beta}\)</span></li>
+<span class="math inline">\(\mathbf{x}_i\)</span> is the <span class="math inline">\(i\)</span>th row of <span class="math inline">\(\mathbf{X}\)</span>.</li>
+<li><span class="math inline">\(h_{ii} = \mathbf{x}_i(\mathbf{X}^{\top}\mathbf{X})^{-1}\mathbf{x}^{\top}_i\)</span></li>
+<li><span class="math inline">\(e_i = y_i - \mathbf{x}_i\widehat{\beta}\)</span></li>
 <li>
 <span class="math inline">\(\mathrm{diag}[.]\)</span> is an operator that creates a diagonal matrix from a vector</li>
 <li>
@@ -212,27 +213,27 @@
 </colgroup>
 <thead><tr class="header">
 <th><code>se_type =</code></th>
-<th>Variance Estimator (<span class="math inline">\(\widehat{{\mathbb{V}}}[\widehat{\beta}]\)</span>)</th>
+<th>Variance Estimator (<span class="math inline">\(\widehat{\mathbb{V}}[\widehat{\beta}]\)</span>)</th>
 <th>Degrees of Freedom</th>
 <th>Notes</th>
 </tr></thead>
 <tbody>
 <tr class="odd">
 <td><code>"CR0"</code></td>
-<td><span class="math inline">\({({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}\sum^S_{s=1} \left[{\mathbf{X}}^\top_s {\mathbf{e}}_s{\mathbf{e}}^\top_s {\mathbf{X}}_s \right] {({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}\)</span></td>
+<td><span class="math inline">\((\mathbf{X}^{\top}\mathbf{X})^{-1} \sum^S_{s=1} \left[\mathbf{X}^\top_s \mathbf{e}_s\mathbf{e}^\top_s \mathbf{X}_s \right] (\mathbf{X}^{\top}\mathbf{X})^{-1}\)</span></td>
 <td><span class="math inline">\(S - 1\)</span></td>
 <td></td>
 </tr>
 <tr class="even">
 <td><code>"stata"</code></td>
-<td><span class="math inline">\(\frac{N-1}{N-K}\frac{S}{S-1} {({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}\sum^S_{s=1} \left[{\mathbf{X}}^\top_s {\mathbf{e}}_s{\mathbf{e}}^\top_s {\mathbf{X}}_s \right] {({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}\)</span></td>
+<td><span class="math inline">\(\frac{N-1}{N-K}\frac{S}{S-1} (\mathbf{X}^{\top}\mathbf{X})^{-1} \sum^S_{s=1} \left[\mathbf{X}^\top_s \mathbf{e}_s\mathbf{e}^\top_s \mathbf{X}_s \right] (\mathbf{X}^{\top}\mathbf{X})^{-1}\)</span></td>
 <td><span class="math inline">\(S - 1\)</span></td>
 <td>The Stata variance estimator is the same as the CR0 estimate but with a special finite-sample correction.</td>
 </tr>
 <tr class="odd">
 <td>
 <code>"CR2"</code> (default)</td>
-<td><span class="math inline">\({({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}\sum^S_{s=1} \left[{\mathbf{X}}^\top_s {\mathbf{A}}_s {\mathbf{e}}_s{\mathbf{e}}^\top_s {\mathbf{A}}^\top_s {\mathbf{X}}_s \right] {({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}\)</span></td>
+<td><span class="math inline">\((\mathbf{X}^{\top}\mathbf{X})^{-1} \sum^S_{s=1} \left[\mathbf{X}^\top_s \mathbf{A}_s \mathbf{e}_s\mathbf{e}^\top_s \mathbf{A}^\top_s \mathbf{X}_s \right] (\mathbf{X}^{\top}\mathbf{X})^{-1}\)</span></td>
 <td><span class="math inline">\(\frac{\left(\sum^S_{i = 1} \mathbf{p}^\top_i \mathbf{p}_i \right)^2}{\sum^S_{i=1}\sum^S_{j=1} \left(\mathbf{p}^\top_i \mathbf{p}_j \right)^2}\)</span></td>
 <td>These estimates of the variance and degrees of freedom come from <span class="citation">Pustejovsky and Tipton (<a href="#ref-pustejovskytipton2016">2016</a>)</span>, which is an extension to certain models with a particular set of dummy variables of the method proposed by <span class="citation">Bell and McCaffrey (<a href="#ref-bellmccaffrey2002">2002</a>)</span>. Note that the degrees of freedom can vary for each coefficient. See below for more complete notation.</td>
 </tr>
@@ -242,38 +243,38 @@
 <li>
 <span class="math inline">\(S\)</span> is the number of clusters</li>
 <li>
-<span class="math inline">\({\mathbf{X}}_s\)</span> is the rows of <span class="math inline">\({\mathbf{X}}\)</span> that belong to cluster <span class="math inline">\(s\)</span>
+<span class="math inline">\(\mathbf{X}_s\)</span> is the rows of <span class="math inline">\(\mathbf{X}\)</span> that belong to cluster <span class="math inline">\(s\)</span>
 </li>
 <li>
 <span class="math inline">\(I_n\)</span> is an identity matrix of size <span class="math inline">\(n\times n\)</span>
 </li>
 <li>
-<span class="math inline">\({\mathbf{e}}_s\)</span> is the elements of the residual matrix <span class="math inline">\({\mathbf{e}}\)</span> in cluster <span class="math inline">\(s\)</span>, or <span class="math inline">\({\mathbf{e}}_s = {\mathbf{y}}_s - {\mathbf{X}}_s \widehat{\beta}\)</span>
+<span class="math inline">\(\mathbf{e}_s\)</span> is the elements of the residual matrix <span class="math inline">\(\mathbf{e}\)</span> in cluster <span class="math inline">\(s\)</span>, or <span class="math inline">\(\mathbf{e}_s = \mathbf{y}_s - \mathbf{X}_s \widehat{\beta}\)</span>
 </li>
 <li>
-<span class="math inline">\({\mathbf{A}}_s\)</span> and <span class="math inline">\(\mathbf{p}\)</span> are defined in the notes below</li>
+<span class="math inline">\(\mathbf{A}_s\)</span> and <span class="math inline">\(\mathbf{p}\)</span> are defined in the notes below</li>
 </ul>
 <p><strong>Further notes on CR2:</strong> The variance estimator we implement is shown in equations (4) and (5) in <span class="citation">Pustejovsky and Tipton (<a href="#ref-pustejovskytipton2016">2016</a>)</span> and equation (11), where we set <span class="math inline">\(\mathbf{\Phi}\)</span> to be <span class="math inline">\(I\)</span>, following <span class="citation">Bell and McCaffrey (<a href="#ref-bellmccaffrey2002">2002</a>)</span>. Furthernote that the <span class="citation">Pustejovsky and Tipton (<a href="#ref-pustejovskytipton2016">2016</a>)</span> CR2 estimator and the <span class="citation">Bell and McCaffrey (<a href="#ref-bellmccaffrey2002">2002</a>)</span> estimator are identical when <span class="math inline">\(\mathbf{B_s}\)</span> is full rank. It could be rank-deficient if there were dummy variables, or fixed effects, that were also your clusters. In this case, the original <span class="citation">Bell and McCaffrey (<a href="#ref-bellmccaffrey2002">2002</a>)</span> estimator could not be computed. You can see the simpler <span class="citation">Bell and McCaffrey (<a href="#ref-bellmccaffrey2002">2002</a>)</span> estimator written up plainly on page 709 of <span class="citation">Imbens and Kolesar (<a href="#ref-imbenskolesar2016">2016</a>)</span> along with the degrees of freedom denoted as <span class="math inline">\(K_{BM}\)</span>.</p>
-<p>In the CR2 variance calculation, we get <span class="math inline">\({\mathbf{A}}_s\)</span> as follows:</p>
+<p>In the CR2 variance calculation, we get <span class="math inline">\(\mathbf{A}_s\)</span> as follows:</p>
 <p><span class="math display">\[
 \begin{aligned}
-{\mathbf{H}}&amp;= {\mathbf{X}}{({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}{\mathbf{X}}^\top \\ 
-\mathbf{B}_s &amp;= (I_{N} - {\mathbf{H}})_s (I_{N} - {\mathbf{H}})^\top_s \\
-{\mathbf{A}}_s &amp;= \mathbf{B}^{+1/2}_s
+\mathbf{H} &amp;= \mathbf{X}(\mathbf{X}^{\top}\mathbf{X})^{-1}\mathbf{X}^\top \\\\\\ 
+\mathbf{B}_s &amp;= (I_{N} - \mathbf{H})_s (I_{N} - \mathbf{H})^\top_s \\\\\\
+\mathbf{A}_s &amp;= \mathbf{B}^{+1/2}_s
 \end{aligned}
 \]</span></p>
-<p>where <span class="math inline">\(\mathbf{B}^{+1/2}_s\)</span> is the symmetric square root of the Moore–Penrose inverse of <span class="math inline">\(\mathbf{B}_s\)</span> and <span class="math inline">\((I - {\mathbf{H}})_s\)</span> are the <span class="math inline">\(N_s\)</span> columns that correspond to cluster <span class="math inline">\(s\)</span>. To get the corresponding degrees of freedom, note that</p>
+<p>where <span class="math inline">\(\mathbf{B}^{+1/2}_s\)</span> is the symmetric square root of the Moore–Penrose inverse of <span class="math inline">\(\mathbf{B}_s\)</span> and <span class="math inline">\((I - \mathbf{H})_s\)</span> are the <span class="math inline">\(N_s\)</span> columns that correspond to cluster <span class="math inline">\(s\)</span>. To get the corresponding degrees of freedom, note that</p>
 <p><span class="math display">\[
-\mathbf{p}_s = (I_N - {\mathbf{H}})^\top_s {\mathbf{A}}_s {\mathbf{X}}_s {({\mathbf{X}}^{\top}{\mathbf{X}})^{-1}}\mathbf{z}_{k}
+\mathbf{p}_s = (I_N - \mathbf{H})^\top_s \mathbf{A}_s \mathbf{X}_s (\mathbf{X}^{\top}\mathbf{X})^{-1} \mathbf{z}_{k}
 \]</span> where <span class="math inline">\(\mathbf{z}_{k}\)</span> is a vector of length <span class="math inline">\(K\)</span>, the number of coefficients, where the <span class="math inline">\(k\)</span>th element is 1 and all other elements are 0. The <span class="math inline">\(k\)</span> signifies the coefficient for which we are computing the degrees of freedom.</p>
 </div>
 </div>
 <div id="confidence-intervals-and-hypothesis-testing" class="section level3">
 <h3 class="hasAnchor">
 <a href="#confidence-intervals-and-hypothesis-testing" class="anchor"></a>Confidence intervals and hypothesis testing</h3>
-<p>If <span class="math inline">\(\widehat{{\mathbb{V}}}_k\)</span> is the <span class="math inline">\(k\)</span>th diagonal element of <span class="math inline">\(\widehat{{\mathbb{V}}}\)</span>, we build confidence intervals using the user specified <span class="math inline">\(\alpha\)</span> as:</p>
+<p>If <span class="math inline">\(\widehat{\mathbb{V}}_k\)</span> is the <span class="math inline">\(k\)</span>th diagonal element of <span class="math inline">\(\widehat{\mathbb{V}}\)</span>, we build confidence intervals using the user specified <span class="math inline">\(\alpha\)</span> as:</p>
 <p><span class="math display">\[
-\mathrm{CI}^{1-\alpha} = \left(\widehat{\beta_k} + t^{df}_{\alpha/2} \sqrt{\widehat{{\mathbb{V}}}_k}, \widehat{\beta_k} + t^{df}_{1 - \alpha/2} \sqrt{\widehat{{\mathbb{V}}}_k}\right)
+\mathrm{CI}^{1-\alpha} = \left(\widehat{\beta_k} + t^{df}_{\alpha/2} \sqrt{\widehat{\mathbb{V}}_k}, \widehat{\beta_k} + t^{df}_{1 - \alpha/2} \sqrt{\widehat{\mathbb{V}}_k}\right)
 \]</span></p>
 <p>We also provide two-sided p-values using a t-distribution with the aforementioned significance level <span class="math inline">\(\alpha\)</span> and degrees of freedom <span class="math inline">\(df\)</span>.</p>
 </div>
@@ -284,13 +285,13 @@
 <p>The <a href="#lm_lin"><code>lm_lin</code></a> estimator is a data pre-processor for <code>lm_robust</code> that implements the regression method for covariate adjustment suggested by <span class="citation">Lin (<a href="#ref-lin2013">2013</a>)</span>.</p>
 <p>This estimator works by taking the outcome and treatment variable as the main formula (<code>formula</code>) and takes a right-sided formula of all pre-treatment covariates (<code>covariates</code>). These pre-treatment covariates are then centered to be mean zero and interacted with the treatment variable before being added to the formula and passed to <code>lm_robust</code>. In other words, instead of fitting a simple model adjusting for pre-treatment covariates such as</p>
 <p><span class="math display">\[
-y_i = \tau z_i + \mathbf{\beta}^\top {\mathbf{x}}_i + \epsilon_i
+y_i = \tau z_i + \mathbf{\beta}^\top \mathbf{x}_i + \epsilon_i
 \]</span></p>
 <p>with the following model</p>
 <p><span class="math display">\[
-y_i = \tau z_i + \mathbf{\beta}^\top \widetilde{{\mathbf{x}}}_i  + \mathbf{\gamma}^\top \widetilde{{\mathbf{x}}}_i z_i + \epsilon_i
+y_i = \tau z_i + \mathbf{\beta}^\top \widetilde{\mathbf{x}}_i  + \mathbf{\gamma}^\top \widetilde{\mathbf{x}}_i z_i + \epsilon_i
 \]</span></p>
-<p>where <span class="math inline">\(\widetilde{{\mathbf{x}}}_i\)</span> is a vector of pre-treatment covariates for unit <span class="math inline">\(i\)</span> that have been centered to have mean zero and <span class="math inline">\(z_i\)</span> is an indicator for the treatment group. <span class="citation">Lin (<a href="#ref-lin2013">2013</a>)</span> proposed this estimator in response to the critique by <span class="citation">Freedman (<a href="#ref-freedman2008">2008</a>)</span> that using regression to adjust for pre-treatment covariates could bias estimates of treatment effects.</p>
+<p>where <span class="math inline">\(\widetilde{\mathbf{x}}_i\)</span> is a vector of pre-treatment covariates for unit <span class="math inline">\(i\)</span> that have been centered to have mean zero and <span class="math inline">\(z_i\)</span> is an indicator for the treatment group. <span class="citation">Lin (<a href="#ref-lin2013">2013</a>)</span> proposed this estimator in response to the critique by <span class="citation">Freedman (<a href="#ref-freedman2008">2008</a>)</span> that using regression to adjust for pre-treatment covariates could bias estimates of treatment effects.</p>
 <p>The estimator <code>lm_lin</code> also works for multi-valued treatments by creating a full set of dummies for each treatment level and interacting each with the centered pre-treatment covariates. The rest of the options for the function and corresponding estimation is identical to <a href="#lm_robust"><code>lm_robust</code></a>.</p>
 </div>
 <div id="difference_in_means-notes" class="section level2">
@@ -336,7 +337,7 @@ y_i = \tau z_i + \mathbf{\beta}^\top \widetilde{{\mathbf{x}}}_i  + \mathbf{\gamm
 </colgroup>
 <thead><tr class="header">
 <th>Design type</th>
-<th>Variance <span class="math inline">\(\widehat{{\mathbb{V}}}[\widehat{\tau}]\)</span>
+<th>Variance <span class="math inline">\(\widehat{\mathbb{V}}[\widehat{\tau}]\)</span>
 </th>
 <th>Degrees of Freedom</th>
 <th>Notes</th>
@@ -344,15 +345,15 @@ y_i = \tau z_i + \mathbf{\beta}^\top \widetilde{{\mathbf{x}}}_i  + \mathbf{\gamm
 <tbody>
 <tr class="odd">
 <td>No blocks or clusters (standard)</td>
-<td><span class="math inline">\(\frac{\widehat{{\mathbb{V}}}[y_{i,0}]}{N_0} + \frac{\widehat{{\mathbb{V}}}[y_{i,1}]}{N_1}\)</span></td>
-<td><span class="math inline">\(\widehat{{\mathbb{V}}}[\widehat{\tau}]^2 \left(\frac{(\widehat{{\mathbb{V}}}[y_{i,1}]/ N_1)^2}{N_1 - 1} + \frac{(\widehat{{\mathbb{V}}}[y_{i,0}]/ N_0)^2}{N_0 - 1}\right)\)</span></td>
-<td>Where <span class="math inline">\(\widehat{{\mathbb{V}}}[y_{i,k}]\)</span> is the Bessel-corrected variance of all units where <span class="math inline">\(z_i = k\)</span> and <span class="math inline">\(N_k\)</span> is the number of units in condition <span class="math inline">\(k\)</span>. This is equivalent to the variance and Welch–Satterthwaite approximation of the degrees of freedom used by R’s <code>t.test</code>.</td>
+<td><span class="math inline">\(\frac{\widehat{\mathbb{V}}[y_{i,0}]}{N_0} + \frac{\widehat{\mathbb{V}}[y_{i,1}]}{N_1}\)</span></td>
+<td><span class="math inline">\(\widehat{\mathbb{V}}[\widehat{\tau}]^2 \left(\frac{(\widehat{\mathbb{V}}[y_{i,1}]/ N_1)^2}{N_1 - 1} + \frac{(\widehat{\mathbb{V}}[y_{i,0}]/ N_0)^2}{N_0 - 1}\right)\)</span></td>
+<td>Where <span class="math inline">\(\widehat{\mathbb{V}}[y_{i,k}]\)</span> is the Bessel-corrected variance of all units where <span class="math inline">\(z_i = k\)</span> and <span class="math inline">\(N_k\)</span> is the number of units in condition <span class="math inline">\(k\)</span>. This is equivalent to the variance and Welch–Satterthwaite approximation of the degrees of freedom used by R’s <code>t.test</code>.</td>
 </tr>
 <tr class="even">
 <td>Blocked</td>
-<td><span class="math inline">\(\sum^J_{j=1} \left(\frac{N_j}{N}\right)^2 \widehat{{\mathbb{V}}}[\widehat{\tau_j}]\)</span></td>
+<td><span class="math inline">\(\sum^J_{j=1} \left(\frac{N_j}{N}\right)^2 \widehat{\mathbb{V}}[\widehat{\tau_j}]\)</span></td>
 <td><span class="math inline">\(N - 2 * J\)</span></td>
-<td>Where <span class="math inline">\(\widehat{{\mathbb{V}}}[\widehat{\tau_j}]\)</span> is the variance of the estimated difference-in-means in block <span class="math inline">\(j\)</span>. See footnote 17 on page 74 of <span class="citation">(Gerber and Green <a href="#ref-gerbergreen2012">2012</a>)</span> for a reference. The degrees of freedom are equivalent to a regression with a full set of block specific treatment effects.</td>
+<td>Where <span class="math inline">\(\widehat{\mathbb{V}}[\widehat{\tau_j}]\)</span> is the variance of the estimated difference-in-means in block <span class="math inline">\(j\)</span>. See footnote 17 on page 74 of <span class="citation">(Gerber and Green <a href="#ref-gerbergreen2012">2012</a>)</span> for a reference. The degrees of freedom are equivalent to a regression with a full set of block specific treatment effects.</td>
 </tr>
 <tr class="odd">
 <td>Clusters</td>
@@ -362,9 +363,9 @@ y_i = \tau z_i + \mathbf{\beta}^\top \widetilde{{\mathbf{x}}}_i  + \mathbf{\gamm
 </tr>
 <tr class="even">
 <td>Blocked and clustered</td>
-<td><span class="math inline">\(\sum^J_{j=1} \left(\frac{N_j}{N}\right)^2 \widehat{{\mathbb{V}}}[\widehat{\tau_j}]\)</span></td>
+<td><span class="math inline">\(\sum^J_{j=1} \left(\frac{N_j}{N}\right)^2 \widehat{\mathbb{V}}[\widehat{\tau_j}]\)</span></td>
 <td><span class="math inline">\(S - 2 * J\)</span></td>
-<td>Where <span class="math inline">\(\widehat{{\mathbb{V}}}[\widehat{\tau_j}]\)</span> is the variance of the estimated difference-in-means in block <span class="math inline">\(j\)</span> and S is the number of clusters. See footnote 17 on page 74 of <span class="citation">Gerber and Green (<a href="#ref-gerbergreen2012">2012</a>)</span> for a reference. The degrees of freedom are equivalent to a regression on data collapsed by cluster with a full set of block specific treatment effects.</td>
+<td>Where <span class="math inline">\(\widehat{\mathbb{V}}[\widehat{\tau_j}]\)</span> is the variance of the estimated difference-in-means in block <span class="math inline">\(j\)</span> and S is the number of clusters. See footnote 17 on page 74 of <span class="citation">Gerber and Green (<a href="#ref-gerbergreen2012">2012</a>)</span> for a reference. The degrees of freedom are equivalent to a regression on data collapsed by cluster with a full set of block specific treatment effects.</td>
 </tr>
 <tr class="odd">
 <td>Matched pairs</td>
@@ -386,7 +387,7 @@ y_i = \tau z_i + \mathbf{\beta}^\top \widetilde{{\mathbf{x}}}_i  + \mathbf{\gamm
 <a href="#confidence-intervals-and-hypothesis-testing-1" class="anchor"></a>Confidence intervals and hypothesis testing</h3>
 <p>We build confidence intervals using the user specified <span class="math inline">\(\alpha\)</span> as:</p>
 <p><span class="math display">\[
-\mathrm{CI}^{1-\alpha} = \left(\widehat{\tau} + t^{df}_{\alpha/2} \sqrt{\widehat{{\mathbb{V}}}[\widehat{\tau}]},\widehat{\tau}] + t^{df}_{1 - \alpha/2} \sqrt{\widehat{{\mathbb{V}}}[\widehat{\tau}]}\right)
+\mathrm{CI}^{1-\alpha} = \left(\widehat{\tau} + t^{df}_{\alpha/2} \sqrt{\widehat{\mathbb{V}}[\widehat{\tau}]},\widehat{\tau}] + t^{df}_{1 - \alpha/2} \sqrt{\widehat{\mathbb{V}}[\widehat{\tau}]}\right)
 \]</span></p>
 <p>We also provide two-sided p-values using a t-distribution with the aforementioned significance level <span class="math inline">\(\alpha\)</span> and degrees of freedom <span class="math inline">\(df\)</span>.</p>
 </div>
@@ -433,8 +434,8 @@ y_i = \tau z_i + \mathbf{\beta}^\top \widetilde{{\mathbf{x}}}_i  + \mathbf{\gamm
 <p>For designs that that are not clustered we use the following variance:</p>
 <p><span class="math display">\[
 \begin{aligned}
-  \widehat{{\mathbb{V}}}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[&amp; z_i \left(\frac{y_i}{\pi_{1i}}\right)^2 + (1 - z_i) \left(\frac{y_i}{\pi_{0i}}\right)^2 + \sum_{j \neq i} \bigg(\frac{z_i z_j}{\pi_{1i1j} + \epsilon_{1i1j}}(\pi_{1i1j} - \pi_{1i}\pi_{1j})\frac{y_i}{\pi_{1i}}\frac{y_j}{\pi_{1j}} \\
-  &amp; + \frac{(1-z_i) (1-z_j)}{\pi_{0i0j} + \epsilon_{0i0j}}(\pi_{0i0j} - \pi_{0i}\pi_{0j})\frac{y_i}{\pi_{0i}}\frac{y_j}{\pi_{0j}} - 2 \frac{z_i (1-z_j)}{\pi_{1i0j} + \epsilon_{1i0j}}(\pi_{1i0j} - \pi_{1i}\pi_{0j})\frac{y_i}{\pi_{1i}}\frac{y_j}{\pi_{0j}} \\
+  \widehat{\mathbb{V}}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[&amp; z_i \left(\frac{y_i}{\pi_{1i}}\right)^2 + (1 - z_i) \left(\frac{y_i}{\pi_{0i}}\right)^2 + \sum_{j \neq i} \bigg(\frac{z_i z_j}{\pi_{1i1j} + \epsilon_{1i1j}}(\pi_{1i1j} - \pi_{1i}\pi_{1j})\frac{y_i}{\pi_{1i}}\frac{y_j}{\pi_{1j}} \\\\\\
+  &amp; + \frac{(1-z_i) (1-z_j)}{\pi_{0i0j} + \epsilon_{0i0j}}(\pi_{0i0j} - \pi_{0i}\pi_{0j})\frac{y_i}{\pi_{0i}}\frac{y_j}{\pi_{0j}} - 2 \frac{z_i (1-z_j)}{\pi_{1i0j} + \epsilon_{1i0j}}(\pi_{1i0j} - \pi_{1i}\pi_{0j})\frac{y_i}{\pi_{1i}}\frac{y_j}{\pi_{0j}} \\\\\\
   &amp; + \sum_{\forall j \colon \pi_{1i1j} = 0} \left( z_i \frac{y^2_i}{2\pi_{1i}} + z_j \frac{y^2_j}{\pi_{1j}}\right) + \sum_{\forall j \colon \pi_{0i0j} = 0} \left( (1-z_i) \frac{y^2_i}{2\pi_{0i}} + (1-z_j) \frac{y^2_j}{\pi_{0j}}\right)
   \Bigg]
 \end{aligned}
@@ -442,7 +443,7 @@ y_i = \tau z_i + \mathbf{\beta}^\top \widetilde{{\mathbf{x}}}_i  + \mathbf{\gamm
 <p>There are some simplifications of the above for simpler designs that follow algebraically from the above. For example, if there are no two units for which the joint probability of being in either condition is 0, which is the case for most experiments that are not matched-pair experiments, then we get:</p>
 <p><span class="math display">\[
 \begin{aligned}
-  \widehat{{\mathbb{V}}}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[&amp; z_i \left(\frac{y_i}{\pi_{1i}}\right)^2 + (1 - z_i) \left(\frac{y_i}{\pi_{0i}}\right)^2 + \sum_{j \neq i} \bigg(\frac{z_i z_j}{\pi_{1i1j}}(\pi_{1i1j} - \pi_{1i}\pi_{1j})\frac{y_i}{\pi_{1i}}\frac{y_j}{\pi_{1j}} \\
+  \widehat{\mathbb{V}}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[&amp; z_i \left(\frac{y_i}{\pi_{1i}}\right)^2 + (1 - z_i) \left(\frac{y_i}{\pi_{0i}}\right)^2 + \sum_{j \neq i} \bigg(\frac{z_i z_j}{\pi_{1i1j}}(\pi_{1i1j} - \pi_{1i}\pi_{1j})\frac{y_i}{\pi_{1i}}\frac{y_j}{\pi_{1j}} \\\\\\
   &amp; + \frac{(1-z_i) (1-z_j)}{\pi_{0i0j}}(\pi_{0i0j} - \pi_{0i}\pi_{0j})\frac{y_i}{\pi_{0i}}\frac{y_j}{\pi_{0j}} - 2 \frac{z_i (1-z_j)}{\pi_{1i0j}}(\pi_{1i0j} - \pi_{1i}\pi_{0j})\frac{y_i}{\pi_{1i}}\frac{y_j}{\pi_{0j}}
   \Bigg]
 \end{aligned}
@@ -450,15 +451,15 @@ y_i = \tau z_i + \mathbf{\beta}^\top \widetilde{{\mathbf{x}}}_i  + \mathbf{\gamm
 <p>If we further simplify to the case where there is simple random assignment, and there is absolutely no dependence among units (i.e., <span class="math inline">\(\pi_{ziwj} = \pi_{zi}\pi_{wj} \;\;\forall\;\;z,w,i,j\)</span>), we get:</p>
 <p><span class="math display">\[
 \begin{aligned}
-  \widehat{{\mathbb{V}}}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[&amp; z_i \left(\frac{y_i}{\pi_{1i}}\right)^2 + (1 - z_i) \left(\frac{y_i}{\pi_{0i}}\right)^2\Bigg]
+  \widehat{\mathbb{V}}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[&amp; z_i \left(\frac{y_i}{\pi_{1i}}\right)^2 + (1 - z_i) \left(\frac{y_i}{\pi_{0i}}\right)^2\Bigg]
 \end{aligned}
 \]</span></p>
 <p><strong>Clustered designs</strong></p>
 <p>For clustered designs, we use the following collpased estimator by setting <code>collapsed = TRUE</code>. Here, <span class="math inline">\(M\)</span> is the total number of clusters, <span class="math inline">\(y_k\)</span> is the total of the outcomes <span class="math inline">\(y_i\)</span> for all <span class="math inline">\(i\)</span> units in cluster <span class="math inline">\(k\)</span>, <span class="math inline">\(\pi_zk\)</span> is the marginal probability of cluster <span class="math inline">\(k\)</span> being in condition <span class="math inline">\(z \in \{0, 1\}\)</span>, and <span class="math inline">\(z_k\)</span> and <span class="math inline">\(\pi_{zkwl}\)</span> are defined analogously. Warning! If one passes <code>condition_pr_mat</code> to <code>horvitz_thompson</code> for a clustered design, but not <code>clusters</code>, the function will not use the collapsed estimator the the variance estimate will be innacurate.</p>
 <p><span class="math display">\[
 \begin{aligned}
-  \widehat{{\mathbb{V}}}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^M_{k=1} \Bigg[&amp; z_k \left(\frac{y_k}{\pi_{1k}}\right)^2 + (1 - z_k) \left(\frac{y_k}{\pi_{0k}}\right)^2 + \sum_{l \neq k} \bigg(\frac{z_k z_l}{\pi_{1k1l} + \epsilon_{1k1l}}(\pi_{1k1l} - \pi_{1k}\pi_{1l})\frac{y_k}{\pi_{1k}}\frac{y_l}{\pi_{1l}} \\
-  &amp; + \frac{(1-z_k) (1-z_l)}{\pi_{0k0l} + \epsilon_{0k0l}}(\pi_{0k0l} - \pi_{0k}\pi_{0l})\frac{y_k}{\pi_{0k}}\frac{y_l}{\pi_{0l}} - 2 \frac{z_k (1-z_l)}{\pi_{1k0l} + \epsilon_{1k0l}}(\pi_{1k0l} - \pi_{1k}\pi_{0l})\frac{y_k}{\pi_{1k}}\frac{y_l}{\pi_{0l}} \\
+  \widehat{\mathbb{V}}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^M_{k=1} \Bigg[&amp; z_k \left(\frac{y_k}{\pi_{1k}}\right)^2 + (1 - z_k) \left(\frac{y_k}{\pi_{0k}}\right)^2 + \sum_{l \neq k} \bigg(\frac{z_k z_l}{\pi_{1k1l} + \epsilon_{1k1l}}(\pi_{1k1l} - \pi_{1k}\pi_{1l})\frac{y_k}{\pi_{1k}}\frac{y_l}{\pi_{1l}} \\\\\\
+  &amp; + \frac{(1-z_k) (1-z_l)}{\pi_{0k0l} + \epsilon_{0k0l}}(\pi_{0k0l} - \pi_{0k}\pi_{0l})\frac{y_k}{\pi_{0k}}\frac{y_l}{\pi_{0l}} - 2 \frac{z_k (1-z_l)}{\pi_{1k0l} + \epsilon_{1k0l}}(\pi_{1k0l} - \pi_{1k}\pi_{0l})\frac{y_k}{\pi_{1k}}\frac{y_l}{\pi_{0l}} \\\\\\
   &amp; + \sum_{\forall l \colon \pi_{1k1l} = 0} \left( z_k \frac{y^2_k}{2\pi_{1k}} + z_l \frac{y^2_l}{\pi_{1l}}\right) + \sum_{\forall l \colon \pi_{0k0l} = 0} \left( (1-z_k) \frac{y^2_k}{2\pi_{0k}} + (1-z_l) \frac{y^2_l}{\pi_{0l}}\right)
   \Bigg]
 \end{aligned}
@@ -471,8 +472,8 @@ y_i = \tau z_i + \mathbf{\beta}^\top \widetilde{{\mathbf{x}}}_i  + \mathbf{\gamm
 </ul>
 <p><span class="math display">\[
 \begin{aligned}
-    \widehat{{\mathbb{V}}}_{C}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[&amp; (1 - \pi_{0i}) \pi_{0i} \left(\frac{y_{0i}}{\pi_{0i}}\right)^2 + (1 - \pi_{1i}) \pi_{1i} \left(\frac{y_{1i}}{\pi_{1i}}\right)^2 - 2 y_{1i} y_{0i} \\
-    &amp; + \sum_{j \neq i} \Big( (\pi_{0i0j} - \pi_{0i} \pi_{0j}) \frac{y_{0i}}{\pi_{0i}} \frac{y_{0j}}{\pi_{0j}} + (\pi_{1i1j} - \pi_{1i} \pi_{1j}) \frac{y_{1i}}{\pi_{1i}} \frac{y_{1j}}{\pi_{1j}} \\
+    \widehat{\mathbb{V}}_{C}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[&amp; (1 - \pi_{0i}) \pi_{0i} \left(\frac{y_{0i}}{\pi_{0i}}\right)^2 + (1 - \pi_{1i}) \pi_{1i} \left(\frac{y_{1i}}{\pi_{1i}}\right)^2 - 2 y_{1i} y_{0i} \\\\\\
+    &amp; + \sum_{j \neq i} \Big( (\pi_{0i0j} - \pi_{0i} \pi_{0j}) \frac{y_{0i}}{\pi_{0i}} \frac{y_{0j}}{\pi_{0j}} + (\pi_{1i1j} - \pi_{1i} \pi_{1j}) \frac{y_{1i}}{\pi_{1i}} \frac{y_{1j}}{\pi_{1j}} \\\\\\
     &amp;- 2 (\pi_{1i0j} - \pi_{1i} \pi_{0j}) \frac{y_{1i}}{\pi_{1i}} \frac{y_{0j}}{\pi_{0j}}
   \Big)\Bigg]
 \end{aligned}
@@ -482,7 +483,7 @@ y_i = \tau z_i + \mathbf{\beta}^\top \widetilde{{\mathbf{x}}}_i  + \mathbf{\gamm
 <h3 class="hasAnchor">
 <a href="#confidence-intervals-and-hypothesis-testing-2" class="anchor"></a>Confidence intervals and hypothesis testing</h3>
 <p>Theory on hypothesis testing with the Horvitz-Thompson estimator is yet to be developed. We rely on a normal approximation and construct confidence intervals in the following way: <span class="math display">\[
-\mathrm{CI}^{1-\alpha} = \left(\widehat{\tau} + z_{\alpha/2} \sqrt{\widehat{{\mathbb{V}}}[\widehat{\tau}]}, \widehat{\tau} + z_{1 - \alpha/2} \sqrt{\widehat{{\mathbb{V}}}[\widehat{\tau}]}\right)
+\mathrm{CI}^{1-\alpha} = \left(\widehat{\tau} + z_{\alpha/2} \sqrt{\widehat{\mathbb{V}}[\widehat{\tau}]}, \widehat{\tau} + z_{1 - \alpha/2} \sqrt{\widehat{\mathbb{V}}[\widehat{\tau}]}\right)
 \]</span></p>
 <p>The associated p-values for a two-sided null hypothesis test are computed using a normal disribution and the aforementioned significance level <span class="math inline">\(\alpha\)</span>.</p>
 </div>

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -71,45 +71,56 @@ The `estimatr` package provides `lm_robust()` to quickly fit linear models with 
 Usage largely mimics `lm()`, although it defaults to using Eicker-Huber-White robust standard errors, specifically "HC2" standard errors. More about the exact specifications used can be found in the [technical notes](http://estimatr.declaredesign.org/articles/technical-notes.html#lm_robust-notes) and more about the estimator can be found on its reference page: `lm_robust()`.
 
 ```{r, lm_robust}
-res <- lm_robust(y ~ z + x, data = dat)
-summary(res)
+lmout <- lm_robust(y ~ z + x, data = dat)
+summary(lmout)
 ```
 
 Users can also easily get the output as a data.frame by using `tidy()`.
 ```{r, results="hide"}
-tidy(res)
+tidy(lmout)
 ```
 ```{r, echo=FALSE}
-knitr::kable(tidy(res))
+knitr::kable(tidy(lmout))
 ```
 
 It is straightforward to do cluster-robust inference, by passing the name of your cluster variable to the `clusters =` argument. The default variance estimator with clusters is dubbed 'CR2' because it is analogous to 'HC2' for the clustered case, and utilizes recent advances proposed by @pustejovskytipton2016 to correct hypotheses tests for small samples and work with commonly specified fixed effects and weights. Note that `lm_robust()` is quicker if your cluster variable is a factor!
 
 ```{r, echo=TRUE, results="hide"}
-res_cl <- lm_robust(
+# Standard estimator with clustered assignment 'z_clust'
+lmout <- lm_robust(
+  y_clust ~ z_clust + x,
+  data = dat
+)
+```
+```{r echo=FALSE}
+knitr::kable(tidy(lmout))
+```
+```{r, echo=TRUE, results="hide"}
+# With clustered standard errors
+lmout_cl <- lm_robust(
   y_clust ~ z_clust + x,
   data = dat,
   clusters = clust
 )
-tidy(res_cl)
+tidy(lmout_cl)
 ```
 ```{r echo=FALSE}
-knitr::kable(tidy(res_cl))
+knitr::kable(tidy(lmout_cl))
 ```
 
 Researchers can also replicate Stata's standard errors by using the `se_type =` argument both with and without clusters:
 
 ```{r echo=TRUE, results="hide"}
-res_stata <- lm_robust(
+lmout_stata <- lm_robust(
   y_clust ~ z_clust + x,
   data = dat,
   clusters = clust,
   se_type = "stata"
 )
-tidy(res_stata)
+tidy(lmout_stata)
 ```
 ```{r echo=FALSE}
-knitr::kable(tidy(res_stata))
+knitr::kable(tidy(lmout_stata))
 ```
 
 Furthermore, users can take advantage of the [`margins`](https://github.com/leeper/margins) package to get marginal effects, average marginal effects and their standard errors, and more.
@@ -117,12 +128,12 @@ Furthermore, users can take advantage of the [`margins`](https://github.com/leep
 ```{r margins, echo=TRUE}
 library(margins)
 
-res_int <- lm_robust(y ~ x * z, data = dat)
-mar_int <- margins(res_int, vce = "delta")
+lmout_int <- lm_robust(y ~ x * z, data = dat)
+mar_int <- margins(lmout_int, vce = "delta")
 summary(mar_int)
 ```
 
-Users who want their regression output in LaTeX or HTML can use the [`texreg`](https://github.com/leifeld/texreg) package, which we extend here to work with our linear regression estimators.
+Users who want their regression output in LaTeX or HTML can use the [`texreg`](https://github.com/leifeld/texreg) package, which we extend for the output of both the `lm_robust()` and `lm_lin()` functions.
 
 ```{r texreg, echo=TRUE, eval=FALSE}
 library(texreg)
@@ -138,51 +149,52 @@ Adjusting for pre-treatment covariates when using regression to estimate treatme
 To facilitate this, we provide a wrapper that processes the data and estimates the model. We dub this estimator the Lin estimator and it can be accessed using `lm_lin()`. This function is a wrapper for `lm_robust()`, and all arguments that work for `lm_robust()` work here. The only difference is in the second argument `covariates`, where one specifies a right-sided formula with all of your pre-treatment covariates. Below is an example, and more can be seen on the function reference page [`lm_lin`](#lm_lin) and some formal notation can be seen in the [technical notes](http://estimatr.declaredesign.org/articles/technical-notes.html#lm_lin-notes).
 
 ```{r echo=TRUE, results="hide"}
-res_lin <- lm_lin(
+lml_out <- lm_lin(
   y ~ z,
   covariates = ~ x,
   data = dat
 )
-tidy(res_lin)
+tidy(lml_out)
 ```
 ```{r echo=FALSE}
-knitr::kable(tidy(res_lin))
+knitr::kable(tidy(lml_out))
 ```
 
 The output of a `lm_lin()` call can be used with the same methods as `lm_robust()`, including the [`margins`](https://github.com/leeper/margins) package.
 
 ## `difference_in_means`
 
-While estimating differences in means may seem straightforward, we provide a function that appropriately adjusts estimates for experimental design. We provide support for unit-randomized, cluster-randomized, block-randomized, matched-pair randomized, and matched-pair clustered designs. Usage is similar to usage in regression functions. More examples can be seen on the function reference page, `difference_in_means()`, and the actual estimators used can be found in the [technical notes](articles/technical-notes.html#lm_robust-notes).
+While estimating differences in means may seem straightforward, it can become more complicated in designs with blocks or clusters. In these cases, estimators need to average over within-block effects and estimates of variance have to appropriately adjust for features of a design. We provide support for unit-randomized, cluster-randomized, block-randomized, matched-pair randomized, and matched-pair clustered designs. Usage is similar to usage in regression functions. More examples can be seen on the function reference page, `difference_in_means()`, and the actual estimators used can be found in the [technical notes](articles/technical-notes.html#lm_robust-notes).
 
 ```{r echo=TRUE, results="hide"}
 # Simple version
-res_dim <- difference_in_means(
+dim_out <- difference_in_means(
   y ~ z,
   data = dat
 )
-tidy(res_dim)
+tidy(dim_out)
 ```
 ```{r echo=FALSE}
-knitr::kable(tidy(res_dim))
+knitr::kable(tidy(dim_out))
 ```
 ```{r echo=TRUE, results="hide"}
 # Clustered version
-res_dim_cl <- difference_in_means(
+dim_out_cl <- difference_in_means(
   y_clust ~ z_clust,
   data = dat,
   clusters = clust
 )
+tidy(dim_out_cl)
 ```
 ```{r echo=FALSE}
-knitr::kable(tidy(res_dim_cl))
+knitr::kable(tidy(dim_out_cl))
 ```
 
 You can check which design was learned and which kind of estimator used by examining the `design` in the output.
 ```{r mp}
 data(sleep)
-res_mps <- difference_in_means(extra ~ group, data = sleep, blocks = ID)
-res_mps$design
+dim_mps <- difference_in_means(extra ~ group, data = sleep, blocks = ID)
+dim_mps$design
 ```
 
 ## `horvitz_thompson`

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -9,20 +9,10 @@ bibliography: estimatr.bib
 vignette: |
   %\VignetteIndexEntry{Getting started using estimatr} 
   \usepackage[utf8]{inputenc}
-  %\VignetteEngine{knitr::knitr}
+  %\VignetteEngine{knitr::rmarkdown}
 editor_options: 
   chunk_output_type: console
 ---
-
-\newcommand{\X}{\mathbf{X}}
-\newcommand{\Pb}{\mathbf{P}}
-\newcommand{\Gb}{\mathbf{G}}
-\newcommand{\XtXinv}{(\X^{\top}\X)^{-1}}
-\newcommand{\x}{\mathbf{x}}
-\newcommand{\y}{\mathbf{y}}
-\newcommand{\E}{\mathbb{E}}
-\newcommand{\e}{\mathbf{e}}
-\newcommand{\V}{\mathbb{V}}
 
 ```{r, echo = FALSE}
 set.seed(42)

--- a/vignettes/technical-notes.Rmd
+++ b/vignettes/technical-notes.Rmd
@@ -8,23 +8,10 @@ output:
 bibliography: estimatr.bib
 vignette: |
   %\VignetteIndexEntry{Technical notes for estimatr}
-  %\VignetteEngine{knitr::knitr}
+  %\VignetteEngine{knitr::rmarkdown}
   \usepackage[utf8]{inputenc}
 ---
 
-\newcommand{\X}{\mathbf{X}}
-\newcommand{\Pb}{\mathbf{P}}
-\newcommand{\Gb}{\mathbf{G}}
-\newcommand{\XtXinv}{(\X^{\top}\X)^{-1}}
-\newcommand{\XtWXinv}{(\X^{\top}\W\X)^{-1}}
-\newcommand{\x}{\mathbf{x}}
-\newcommand{\y}{\mathbf{y}}
-\newcommand{\E}{\mathbb{E}}
-\newcommand{\e}{\mathbf{e}}
-\newcommand{\V}{\mathbb{V}}
-\newcommand{\W}{\mathbf{W}}
-\newcommand{\Hb}{\mathbf{H}}
-\newcommand{\Ab}{\mathbf{A}}
 
 ```{r, echo = FALSE}
 set.seed(42)
@@ -55,25 +42,23 @@ The default estimators have been selected for efficiency in large samples and lo
 ### Coefficient estimates
 
 \[
-\widehat{\beta} =\XtXinv\X^{\top}\y
+\widehat{\beta} =(\mathbf{X}^{\top}\mathbf{X})^{-1}\mathbf{X}^{\top}\mathbf{y}
 \]
 
-Our algorithm solves the least squares problem using a rank-revealing column-pivoting QR factorization that eliminates the need to invert $\XtXinv$ explicitly and behaves much like the default `lm` function in R. However, when $\X$ is rank deficient, there are certain conditions under which the QR factorization algorithm we use, from the Eigen C++ library, drops different coefficients from the output than the default `lm` function. In general, users should avoid specifing models with rank-deficiencies. In fact, if users are certain their data are not rank deficient, they can improve the speed of `lm_robust` by setting `try_cholesky = TRUE`. This replaces the QR factorization with a Cholesky factorization that is only guaranteed to work $\X$ is of full rank.
+Our algorithm solves the least squares problem using a rank-revealing column-pivoting QR factorization that eliminates the need to invert $(\mathbf{X}^{\top}\mathbf{X})^{-1}$ explicitly and behaves much like the default `lm` function in R. However, when $\mathbf{X}$ is rank deficient, there are certain conditions under which the QR factorization algorithm we use, from the Eigen C++ library, drops different coefficients from the output than the default `lm` function. In general, users should avoid specifing models with rank-deficiencies. In fact, if users are certain their data are not rank deficient, they can improve the speed of `lm_robust` by setting `try_cholesky = TRUE`. This replaces the QR factorization with a Cholesky factorization that is only guaranteed to work $\mathbf{X}$ is of full rank.
 
 #### Weights
 
-If weights are included, we transform the data as below and then proceed as normal, following advice from @romanowolf2017 that this weighted estimator has attractive properties. We do so by first scaling all of the weights so that they sum to one. Then we multiply each row of the design matrix $\X$ by the square root each unit's weight, $\mathbf{x}_i \sqrt{w_i}$, and then do the same to the outcome, $\mathbf{y}_i \sqrt{w_i}$. This results in our coefficients being estimated as follows, where $\W$ is a diagonal matrix with the scaled weights on the diagonal.
+If weights are included, we transform the data as below and then proceed as normal, following advice from @romanowolf2017 that this weighted estimator has attractive properties. We do so by first scaling all of the weights so that they sum to one. Then we multiply each row of the design matrix $\mathbf{X}$ by the square root each unit's weight, $\mathbf{x}_i \sqrt{w_i}$, and then do the same to the outcome, $\mathbf{y}_i \sqrt{w_i}$. This results in our coefficients being estimated as follows, where $\mathbf{W}$ is a diagonal matrix with the scaled weights on the diagonal.
 
 Weighted:
 \[
-\widehat{\beta} =\XtWXinv\X^{\top}\W\y
+\widehat{\beta} =(\mathbf{X}^{\top}\mathbf{W}\mathbf{X})^{-1}\mathbf{X}^{\top}\mathbf{W}\mathbf{y}
 \]
 
-The transformed data are then used in the analysis below, where $\XtXinv$ is now $\XtWXinv$ and $\X$ is now $\X \mathrm{sqrt}[W]$, where $\mathrm{sqrt}[.]$ is an operator that applies a square root to the coefficients of some matrix.
+The transformed data are then used in the analysis below, where $(\mathbf{X}^{\top}\mathbf{X})^{-1}$ is now $(\mathbf{X}^{\top}\mathbf{W}\mathbf{X})^{-1}$ and $\mathbf{X}$ is now $\mathbf{X} \mathrm{sqrt}[W]$, where $\mathrm{sqrt}[.]$ is an operator that applies a square root to the coefficients of some matrix.
 
 We should note that this transformation yields the same standard errors as specifying weights using `aweight` in Stata for the "classical", "HC0", and "HC1" ("stata") variance estimators. Furthermore, in the clustered case, our weighted estimator for the "stata" cluster-robust variance also matches Stata. Thus Stata's main robust standard error estimators, "HC1" and their clustered estimator, match our package when weights are applied. Nonetheless, Stata uses a slightly different Hat matrix and thus "HC2" and "HC3" estimates in Stata when weights are specified may differ from our estimates.
-
-```
 
 ### Variance
 
@@ -83,16 +68,16 @@ In addition to solving for OLS coefficients faster than `lm`, we provide a varie
 
 The default variance estimator without clusters is the HC2 variance, first proposed by @mackinnonwhite1985. This estimator has the advantage of being equivalent to a conservative randomization-based "Neyman" estimator of the variance [@samiiaronow2012]. Furthermore, while it is somewhat less efficient than the HC1 variance estimator, the default in Stata, it tends to perform better in small samples.
 
-| `se_type = `      | Variance Estimator ($\widehat{\V}[\widehat{\beta}]$)                                   | Degrees of Freedom | Notes |
+| `se_type = `      | Variance Estimator ($\widehat{\mathbb{V}}[\widehat{\beta}]$)                                   | Degrees of Freedom | Notes |
 |----------|--------------------------|------|----------------------------|
-| `"classical"`     | $\frac{\e^\top\e}{N-K} \XtXinv$                                                | N - K              |       |
-| `"HC0"`           | $\XtXinv\X^{\top}\mathrm{diag}\left[e_i^2\right]\X\XtXinv$                     | N - K              |       |
-| `"HC1"`, `"stata"`| $\frac{N}{N-K}\XtXinv\X^{\top}\mathrm{diag}\left[e_i^2\right]\X\XtXinv$                     | N - K              | Often called the Eicker-Huber-White variance (or similar)      |
-| `"HC2"` (default) | $\XtXinv\X^{\top}\mathrm{diag}\left[\frac{e_i^2}{1-h_{ii}}\right]\X\XtXinv$    | N - K              |       |
-| `"HC3"`           | $\XtXinv\X{\top}\mathrm{diag}\left[\frac{e_i^2}{(1-h_{ii})^2}\right]\X\XtXinv$ | N - K              |       |
-* $\x_i$ is the $i$th row of $\X$.
-* $h_{ii} = \x_i\XtXinv\x^{\top}_i$
-* $e_i = y_i - \x_i\widehat{\beta}$
+| `"classical"`     | $\frac{\mathbf{e}^\top\mathbf{e}}{N-K} (\mathbf{X}^{\top}\mathbf{X})^{-1}$                                                | N - K              |       |
+| `"HC0"`           | $(\mathbf{X}^{\top}\mathbf{X})^{-1}\mathbf{X}^{\top}\mathrm{diag}\left[e_i^2\right]\mathbf{X}(\mathbf{X}^{\top}\mathbf{X})^{-1}$                     | N - K              |       |
+| `"HC1"`, `"stata"`| $\frac{N}{N-K}(\mathbf{X}^{\top}\mathbf{X})^{-1}\mathbf{X}^{\top}\mathrm{diag}\left[e_i^2\right]\mathbf{X}(\mathbf{X}^{\top}\mathbf{X})^{-1}$                     | N - K              | Often called the Eicker-Huber-White variance (or similar)      |
+| `"HC2"` (default) | $(\mathbf{X}^{\top}\mathbf{X})^{-1}\mathbf{X}^{\top}\mathrm{diag}\left[\frac{e_i^2}{1-h_{ii}}\right]\mathbf{X}(\mathbf{X}^{\top}\mathbf{X})^{-1}$    | N - K              |       |
+| `"HC3"`           | $(\mathbf{X}^{\top}\mathbf{X})^{-1}\mathbf{X}{\top}\mathrm{diag}\left[\frac{e_i^2}{(1-h_{ii})^2}\right]\mathbf{X}(\mathbf{X}^{\top}\mathbf{X})^{-1}$ | N - K              |       |
+* $\mathbf{x}_i$ is the $i$th row of $\mathbf{X}$.
+* $h_{ii} = \mathbf{x}_i(\mathbf{X}^{\top}\mathbf{X})^{-1}\mathbf{x}^{\top}_i$
+* $e_i = y_i - \mathbf{x}_i\widehat{\beta}$
 * $\mathrm{diag}[.]$ is an operator that creates a diagonal matrix from a vector
 * $N$ is the number of observations
 * $K$ is the number of elements in $\beta$.
@@ -101,42 +86,42 @@ The default variance estimator without clusters is the HC2 variance, first propo
 
 For cluster-robust inference, we provide several estimators that are essentially analogs of the heteroskedastic-consistent variance estimators for the clustered case. Our default is the CR2 variance estimator, analogous to HC2 standard errors, and perform quite well in small samples without sacrificing much in the way of efficiency in larger samples. This estimator was originally proposed in @bellmccaffrey2002, although we implement a generalized version of the algorithm outlined in @pustejovskytipton2016; these authors provide an R package for CR2 variance estimation, [clubSandwich](https://github.com/jepusto/clubSandwich), that applies these standard errors to a wide variety of models. For a good overview of the different cluster-robust variance estimators and simulations of their accuracy in small samples, again users can see @imbenskolesar2016. For an overview of when to use cluster-robust estimators, especially in an experimental setting, see @abadieetal2017.
 
-| `se_type = `      | Variance Estimator ($\widehat{\V}[\widehat{\beta}]$)                                                           | Degrees of Freedom                                                       | Notes                                                                                                                                                                                                                   |
+| `se_type = `      | Variance Estimator ($\widehat{\mathbb{V}}[\widehat{\beta}]$)                                                           | Degrees of Freedom                                                       | Notes                                                                                                                                                                                                                   |
 |-------------------|--------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `"CR0"`           | $\XtXinv \sum^S_{s=1} \left[\X^\top_s \e_s\e^\top_s \X_s \right] \XtXinv$                              | $S - 1$                                                                    |                                                                                                                                                                                                                         |
-| `"stata"`         | $\frac{N-1}{N-K}\frac{S}{S-1} \XtXinv \sum^S_{s=1} \left[\X^\top_s \e_s\e^\top_s \X_s \right] \XtXinv$ | $S - 1$                                                                    | The Stata variance estimator is the same as the CR0 estimate but with a special finite-sample correction.                                                                                                               |
-| `"CR2"` (default) | $\XtXinv \sum^S_{s=1} \left[\X^\top_s \Ab_s \e_s\e^\top_s \Ab^\top_s \X_s \right] \XtXinv$                 | $\frac{\left(\sum^S_{i = 1} \mathbf{p}^\top_i \mathbf{p}_i \right)^2}{\sum^S_{i=1}\sum^S_{j=1} \left(\mathbf{p}^\top_i \mathbf{p}_j \right)^2}$ | These estimates of the variance and degrees of freedom come from @pustejovskytipton2016, which is an extension to certain models with a particular set of dummy variables of the method proposed by @bellmccaffrey2002. Note that the degrees of freedom can vary for each coefficient. See below for more complete notation. |
+| `"CR0"`           | $(\mathbf{X}^{\top}\mathbf{X})^{-1} \sum^S_{s=1} \left[\mathbf{X}^\top_s \mathbf{e}_s\mathbf{e}^\top_s \mathbf{X}_s \right] (\mathbf{X}^{\top}\mathbf{X})^{-1}$                              | $S - 1$                                                                    |                                                                                                                                                                                                                         |
+| `"stata"`         | $\frac{N-1}{N-K}\frac{S}{S-1} (\mathbf{X}^{\top}\mathbf{X})^{-1} \sum^S_{s=1} \left[\mathbf{X}^\top_s \mathbf{e}_s\mathbf{e}^\top_s \mathbf{X}_s \right] (\mathbf{X}^{\top}\mathbf{X})^{-1}$ | $S - 1$                                                                    | The Stata variance estimator is the same as the CR0 estimate but with a special finite-sample correction.                                                                                                               |
+| `"CR2"` (default) | $(\mathbf{X}^{\top}\mathbf{X})^{-1} \sum^S_{s=1} \left[\mathbf{X}^\top_s \mathbf{A}_s \mathbf{e}_s\mathbf{e}^\top_s \mathbf{A}^\top_s \mathbf{X}_s \right] (\mathbf{X}^{\top}\mathbf{X})^{-1}$                 | $\frac{\left(\sum^S_{i = 1} \mathbf{p}^\top_i \mathbf{p}_i \right)^2}{\sum^S_{i=1}\sum^S_{j=1} \left(\mathbf{p}^\top_i \mathbf{p}_j \right)^2}$ | These estimates of the variance and degrees of freedom come from @pustejovskytipton2016, which is an extension to certain models with a particular set of dummy variables of the method proposed by @bellmccaffrey2002. Note that the degrees of freedom can vary for each coefficient. See below for more complete notation. |
 * $S$ is the number of clusters
-* $\X_s$ is the rows of $\X$ that belong to cluster $s$
+* $\mathbf{X}_s$ is the rows of $\mathbf{X}$ that belong to cluster $s$
 * $I_n$ is an identity matrix of size $n\times n$
-* $\e_s$ is the elements of the residual matrix $\e$ in cluster $s$, or $\e_s = \y_s - \X_s \widehat{\beta}$
-* $\Ab_s$ and $\mathbf{p}$ are defined in the notes below
+* $\mathbf{e}_s$ is the elements of the residual matrix $\mathbf{e}$ in cluster $s$, or $\mathbf{e}_s = \mathbf{y}_s - \mathbf{X}_s \widehat{\beta}$
+* $\mathbf{A}_s$ and $\mathbf{p}$ are defined in the notes below
 
 **Further notes on CR2:** The variance estimator we implement is shown in equations (4) and (5) in @pustejovskytipton2016 and equation (11), where we set $\mathbf{\Phi}$ to be $I$, following @bellmccaffrey2002. Furthernote that the @pustejovskytipton2016 CR2 estimator and the  @bellmccaffrey2002 estimator are identical when $\mathbf{B_s}$ is full rank. It could be rank-deficient if there were dummy variables, or fixed effects, that were also your clusters. In this case, the original @bellmccaffrey2002 estimator could not be computed. You can see the simpler @bellmccaffrey2002 estimator written up plainly on page 709 of @imbenskolesar2016 along with the degrees of freedom denoted as $K_{BM}$.
 
-In the CR2 variance calculation, we get $\Ab_s$ as follows:
+In the CR2 variance calculation, we get $\mathbf{A}_s$ as follows:
 
 $$
 \begin{aligned}
-\Hb &= \X\XtXinv\X^\top \\ 
-\mathbf{B}_s &= (I_{N} - \Hb)_s (I_{N} - \Hb)^\top_s \\
-\Ab_s &= \mathbf{B}^{+1/2}_s
+\mathbf{H} &= \mathbf{X}(\mathbf{X}^{\top}\mathbf{X})^{-1}\mathbf{X}^\top \\\\\\ 
+\mathbf{B}_s &= (I_{N} - \mathbf{H})_s (I_{N} - \mathbf{H})^\top_s \\\\\\
+\mathbf{A}_s &= \mathbf{B}^{+1/2}_s
 \end{aligned}
 $$
 
-where $\mathbf{B}^{+1/2}_s$ is the symmetric square root of the Moore–Penrose inverse of $\mathbf{B}_s$ and $(I - \Hb)_s$ are the $N_s$ columns that correspond to cluster $s$. To get the corresponding degrees of freedom, note that
+where $\mathbf{B}^{+1/2}_s$ is the symmetric square root of the Moore–Penrose inverse of $\mathbf{B}_s$ and $(I - \mathbf{H})_s$ are the $N_s$ columns that correspond to cluster $s$. To get the corresponding degrees of freedom, note that
 
 \[
-\mathbf{p}_s = (I_N - \Hb)^\top_s \Ab_s \X_s \XtXinv \mathbf{z}_{k}
+\mathbf{p}_s = (I_N - \mathbf{H})^\top_s \mathbf{A}_s \mathbf{X}_s (\mathbf{X}^{\top}\mathbf{X})^{-1} \mathbf{z}_{k}
 \]
 where $\mathbf{z}_{k}$ is a vector of length $K$, the number of coefficients, where the $k$th element is 1 and all other elements are 0. The $k$ signifies the coefficient for which we are computing the degrees of freedom.
 
 ### Confidence intervals and hypothesis testing
 
-If $\widehat{\V}_k$ is the $k$th diagonal element of $\widehat{\V}$, we build confidence intervals using the user specified $\alpha$ as:
+If $\widehat{\mathbb{V}}_k$ is the $k$th diagonal element of $\widehat{\mathbb{V}}$, we build confidence intervals using the user specified $\alpha$ as:
 
 \[
-\mathrm{CI}^{1-\alpha} = \left(\widehat{\beta_k} + t^{df}_{\alpha/2} \sqrt{\widehat{\V}_k}, \widehat{\beta_k} + t^{df}_{1 - \alpha/2} \sqrt{\widehat{\V}_k}\right)
+\mathrm{CI}^{1-\alpha} = \left(\widehat{\beta_k} + t^{df}_{\alpha/2} \sqrt{\widehat{\mathbb{V}}_k}, \widehat{\beta_k} + t^{df}_{1 - \alpha/2} \sqrt{\widehat{\mathbb{V}}_k}\right)
 \]
 
 We also provide two-sided p-values using a t-distribution with the aforementioned significance level $\alpha$ and degrees of freedom $df$.
@@ -148,16 +133,16 @@ The [`lm_lin`](#lm_lin) estimator is a data pre-processor for `lm_robust` that i
 This estimator works by taking the outcome and treatment variable as the main formula (`formula`) and takes a right-sided formula of all pre-treatment covariates (`covariates`). These pre-treatment covariates are then centered to be mean zero and interacted with the treatment variable before being added to the formula and passed to `lm_robust`. In other words, instead of fitting a simple model adjusting for pre-treatment covariates such as
 
 \[
-y_i = \tau z_i + \mathbf{\beta}^\top \x_i + \epsilon_i
+y_i = \tau z_i + \mathbf{\beta}^\top \mathbf{x}_i + \epsilon_i
 \]
 
 with the following model
 
 \[
-y_i = \tau z_i + \mathbf{\beta}^\top \widetilde{\x}_i  + \mathbf{\gamma}^\top \widetilde{\x}_i z_i + \epsilon_i
+y_i = \tau z_i + \mathbf{\beta}^\top \widetilde{\mathbf{x}}_i  + \mathbf{\gamma}^\top \widetilde{\mathbf{x}}_i z_i + \epsilon_i
 \]
 
-where $\widetilde{\x}_i$ is a vector of pre-treatment covariates for unit $i$ that have been centered to have mean zero and $z_i$ is an indicator for the treatment group. @lin2013 proposed this estimator in response to the critique by @freedman2008 that using regression to adjust for pre-treatment covariates could bias estimates of treatment effects.
+where $\widetilde{\mathbf{x}}_i$ is a vector of pre-treatment covariates for unit $i$ that have been centered to have mean zero and $z_i$ is an indicator for the treatment group. @lin2013 proposed this estimator in response to the critique by @freedman2008 that using regression to adjust for pre-treatment covariates could bias estimates of treatment effects.
 
 The estimator `lm_lin` also works for multi-valued treatments by creating a full set of dummies for each treatment level and interacting each with the centered pre-treatment covariates. The rest of the options for the function and corresponding estimation is identical to [`lm_robust`](#lm_robust).
 
@@ -197,12 +182,12 @@ If the user specifies weights, treatment effects (or block-level treatment effec
 
 ### Variance and Degrees of Freedom
 
-| Design type                     | Variance $\widehat{\V}[\widehat{\tau}]$                                                            | Degrees of Freedom                                                                                                            | Notes                                                                                                                                                                                                                                                                                                                                     |
+| Design type                     | Variance $\widehat{\mathbb{V}}[\widehat{\tau}]$                                                            | Degrees of Freedom                                                                                                            | Notes                                                                                                                                                                                                                                                                                                                                     |
 |---------------------------------|--------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| No blocks or clusters (standard)           | $\frac{\widehat{\V}[y_{i,0}]}{N_0} + \frac{\widehat{\V}[y_{i,1}]}{N_1}$                            | $\widehat{\V}[\widehat{\tau}]^2 \left(\frac{(\widehat{\V}[y_{i,1}]/ N_1)^2}{N_1 - 1} + \frac{(\widehat{\V}[y_{i,0}]/ N_0)^2}{N_0 - 1}\right)$ | Where $\widehat{\V}[y_{i,k}]$ is the Bessel-corrected variance of all units where $z_i = k$ and $N_k$ is the number of units in condition $k$. This is equivalent to the variance and Welch–Satterthwaite approximation of the degrees of freedom used by R's `t.test`.                                                                     |
-| Blocked                         | $\sum^J_{j=1} \left(\frac{N_j}{N}\right)^2 \widehat{\V}[\widehat{\tau_j}]$                         | $N - 2 * J$                                                                                                                     | Where $\widehat{\V}[\widehat{\tau_j}]$ is the variance of the estimated difference-in-means in block $j$. See footnote 17 on page 74 of [@gerbergreen2012] for a reference. The degrees of freedom are equivalent to a regression with a full set of block specific treatment effects.                                                            |
+| No blocks or clusters (standard)           | $\frac{\widehat{\mathbb{V}}[y_{i,0}]}{N_0} + \frac{\widehat{\mathbb{V}}[y_{i,1}]}{N_1}$                            | $\widehat{\mathbb{V}}[\widehat{\tau}]^2 \left(\frac{(\widehat{\mathbb{V}}[y_{i,1}]/ N_1)^2}{N_1 - 1} + \frac{(\widehat{\mathbb{V}}[y_{i,0}]/ N_0)^2}{N_0 - 1}\right)$ | Where $\widehat{\mathbb{V}}[y_{i,k}]$ is the Bessel-corrected variance of all units where $z_i = k$ and $N_k$ is the number of units in condition $k$. This is equivalent to the variance and Welch–Satterthwaite approximation of the degrees of freedom used by R's `t.test`.                                                                     |
+| Blocked                         | $\sum^J_{j=1} \left(\frac{N_j}{N}\right)^2 \widehat{\mathbb{V}}[\widehat{\tau_j}]$                         | $N - 2 * J$                                                                                                                     | Where $\widehat{\mathbb{V}}[\widehat{\tau_j}]$ is the variance of the estimated difference-in-means in block $j$. See footnote 17 on page 74 of [@gerbergreen2012] for a reference. The degrees of freedom are equivalent to a regression with a full set of block specific treatment effects.                                                            |
 | Clusters                        | Same as `lm_robust` CR2 estimator                                                        | Same as `lm_robust` CR2 estimator                                                                                           | This variance is the same as that recommended by @gerbergreen2012 in equation 3.23 on page 83 when the clusters are even sizes.                                                                                                                                                                                                           |
-| Blocked and clustered           | $\sum^J_{j=1} \left(\frac{N_j}{N}\right)^2 \widehat{\V}[\widehat{\tau_j}]$                         | $S - 2 * J$                                                                                                                     | Where $\widehat{\V}[\widehat{\tau_j}]$ is the variance of the estimated difference-in-means in block $j$ and S is the number of clusters. See footnote 17 on page 74 of @gerbergreen2012 for a reference. The degrees of freedom are equivalent to a regression on data collapsed by cluster with a full set of block specific treatment effects. |
+| Blocked and clustered           | $\sum^J_{j=1} \left(\frac{N_j}{N}\right)^2 \widehat{\mathbb{V}}[\widehat{\tau_j}]$                         | $S - 2 * J$                                                                                                                     | Where $\widehat{\mathbb{V}}[\widehat{\tau_j}]$ is the variance of the estimated difference-in-means in block $j$ and S is the number of clusters. See footnote 17 on page 74 of @gerbergreen2012 for a reference. The degrees of freedom are equivalent to a regression on data collapsed by cluster with a full set of block specific treatment effects. |
 | Matched pairs                   | $\frac{1}{J(J-1)} \sum^J_{j=1} \left(\widehat{\tau_j} - \widehat{\tau}\right)^2$                   | $J - 1$                                                                                                                         | See equation 3.16 on page 77 of @gerbergreen2012 for a reference.                                                                                                                                                                                                                                                                         |
 | Matched pair cluster randomized | $\frac{J}{(J-1)N^2} \sum^J_{j=1} \left(N_j \widehat{\tau_j} - \frac{N \widehat{\tau}}{J}\right)^2$ | $J - 1$                                                                                                                        | See the variance for the SATE defined in equation 6 on page 36 of [@imaietal2009] and the suggested degrees of freedom on page 37.                                                                                                                                                                                                        |
 
@@ -211,7 +196,7 @@ If the user specifies weights, treatment effects (or block-level treatment effec
 We build confidence intervals using the user specified $\alpha$ as:
 
 \[
-\mathrm{CI}^{1-\alpha} = \left(\widehat{\tau} + t^{df}_{\alpha/2} \sqrt{\widehat{\V}[\widehat{\tau}]},\widehat{\tau}] + t^{df}_{1 - \alpha/2} \sqrt{\widehat{\V}[\widehat{\tau}]}\right)
+\mathrm{CI}^{1-\alpha} = \left(\widehat{\tau} + t^{df}_{\alpha/2} \sqrt{\widehat{\mathbb{V}}[\widehat{\tau}]},\widehat{\tau}] + t^{df}_{1 - \alpha/2} \sqrt{\widehat{\mathbb{V}}[\widehat{\tau}]}\right)
 \]
 
 We also provide two-sided p-values using a t-distribution with the aforementioned significance level $\alpha$ and degrees of freedom $df$.
@@ -256,8 +241,8 @@ For designs that that are not clustered we use the following variance:
 
 $$
 \begin{aligned}
-  \widehat{\V}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[& z_i \left(\frac{y_i}{\pi_{1i}}\right)^2 + (1 - z_i) \left(\frac{y_i}{\pi_{0i}}\right)^2 + \sum_{j \neq i} \bigg(\frac{z_i z_j}{\pi_{1i1j} + \epsilon_{1i1j}}(\pi_{1i1j} - \pi_{1i}\pi_{1j})\frac{y_i}{\pi_{1i}}\frac{y_j}{\pi_{1j}} \\
-  & + \frac{(1-z_i) (1-z_j)}{\pi_{0i0j} + \epsilon_{0i0j}}(\pi_{0i0j} - \pi_{0i}\pi_{0j})\frac{y_i}{\pi_{0i}}\frac{y_j}{\pi_{0j}} - 2 \frac{z_i (1-z_j)}{\pi_{1i0j} + \epsilon_{1i0j}}(\pi_{1i0j} - \pi_{1i}\pi_{0j})\frac{y_i}{\pi_{1i}}\frac{y_j}{\pi_{0j}} \\
+  \widehat{\mathbb{V}}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[& z_i \left(\frac{y_i}{\pi_{1i}}\right)^2 + (1 - z_i) \left(\frac{y_i}{\pi_{0i}}\right)^2 + \sum_{j \neq i} \bigg(\frac{z_i z_j}{\pi_{1i1j} + \epsilon_{1i1j}}(\pi_{1i1j} - \pi_{1i}\pi_{1j})\frac{y_i}{\pi_{1i}}\frac{y_j}{\pi_{1j}} \\\\\\
+  & + \frac{(1-z_i) (1-z_j)}{\pi_{0i0j} + \epsilon_{0i0j}}(\pi_{0i0j} - \pi_{0i}\pi_{0j})\frac{y_i}{\pi_{0i}}\frac{y_j}{\pi_{0j}} - 2 \frac{z_i (1-z_j)}{\pi_{1i0j} + \epsilon_{1i0j}}(\pi_{1i0j} - \pi_{1i}\pi_{0j})\frac{y_i}{\pi_{1i}}\frac{y_j}{\pi_{0j}} \\\\\\
   & + \sum_{\forall j \colon \pi_{1i1j} = 0} \left( z_i \frac{y^2_i}{2\pi_{1i}} + z_j \frac{y^2_j}{\pi_{1j}}\right) + \sum_{\forall j \colon \pi_{0i0j} = 0} \left( (1-z_i) \frac{y^2_i}{2\pi_{0i}} + (1-z_j) \frac{y^2_j}{\pi_{0j}}\right)
   \Bigg]
 \end{aligned}
@@ -267,7 +252,7 @@ There are some simplifications of the above for simpler designs that follow alge
 
 $$
 \begin{aligned}
-  \widehat{\V}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[& z_i \left(\frac{y_i}{\pi_{1i}}\right)^2 + (1 - z_i) \left(\frac{y_i}{\pi_{0i}}\right)^2 + \sum_{j \neq i} \bigg(\frac{z_i z_j}{\pi_{1i1j}}(\pi_{1i1j} - \pi_{1i}\pi_{1j})\frac{y_i}{\pi_{1i}}\frac{y_j}{\pi_{1j}} \\
+  \widehat{\mathbb{V}}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[& z_i \left(\frac{y_i}{\pi_{1i}}\right)^2 + (1 - z_i) \left(\frac{y_i}{\pi_{0i}}\right)^2 + \sum_{j \neq i} \bigg(\frac{z_i z_j}{\pi_{1i1j}}(\pi_{1i1j} - \pi_{1i}\pi_{1j})\frac{y_i}{\pi_{1i}}\frac{y_j}{\pi_{1j}} \\\\\\
   & + \frac{(1-z_i) (1-z_j)}{\pi_{0i0j}}(\pi_{0i0j} - \pi_{0i}\pi_{0j})\frac{y_i}{\pi_{0i}}\frac{y_j}{\pi_{0j}} - 2 \frac{z_i (1-z_j)}{\pi_{1i0j}}(\pi_{1i0j} - \pi_{1i}\pi_{0j})\frac{y_i}{\pi_{1i}}\frac{y_j}{\pi_{0j}}
   \Bigg]
 \end{aligned}
@@ -277,7 +262,7 @@ If we further simplify to the case where there is simple random assignment, and 
 
 $$
 \begin{aligned}
-  \widehat{\V}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[& z_i \left(\frac{y_i}{\pi_{1i}}\right)^2 + (1 - z_i) \left(\frac{y_i}{\pi_{0i}}\right)^2\Bigg]
+  \widehat{\mathbb{V}}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[& z_i \left(\frac{y_i}{\pi_{1i}}\right)^2 + (1 - z_i) \left(\frac{y_i}{\pi_{0i}}\right)^2\Bigg]
 \end{aligned}
 $$
 
@@ -287,8 +272,8 @@ For clustered designs, we use the following collpased estimator by setting `coll
 
 $$
 \begin{aligned}
-  \widehat{\V}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^M_{k=1} \Bigg[& z_k \left(\frac{y_k}{\pi_{1k}}\right)^2 + (1 - z_k) \left(\frac{y_k}{\pi_{0k}}\right)^2 + \sum_{l \neq k} \bigg(\frac{z_k z_l}{\pi_{1k1l} + \epsilon_{1k1l}}(\pi_{1k1l} - \pi_{1k}\pi_{1l})\frac{y_k}{\pi_{1k}}\frac{y_l}{\pi_{1l}} \\
-  & + \frac{(1-z_k) (1-z_l)}{\pi_{0k0l} + \epsilon_{0k0l}}(\pi_{0k0l} - \pi_{0k}\pi_{0l})\frac{y_k}{\pi_{0k}}\frac{y_l}{\pi_{0l}} - 2 \frac{z_k (1-z_l)}{\pi_{1k0l} + \epsilon_{1k0l}}(\pi_{1k0l} - \pi_{1k}\pi_{0l})\frac{y_k}{\pi_{1k}}\frac{y_l}{\pi_{0l}} \\
+  \widehat{\mathbb{V}}_{Y}[\widehat{\tau}] = \frac{1}{N^2} \sum^M_{k=1} \Bigg[& z_k \left(\frac{y_k}{\pi_{1k}}\right)^2 + (1 - z_k) \left(\frac{y_k}{\pi_{0k}}\right)^2 + \sum_{l \neq k} \bigg(\frac{z_k z_l}{\pi_{1k1l} + \epsilon_{1k1l}}(\pi_{1k1l} - \pi_{1k}\pi_{1l})\frac{y_k}{\pi_{1k}}\frac{y_l}{\pi_{1l}} \\\\\\
+  & + \frac{(1-z_k) (1-z_l)}{\pi_{0k0l} + \epsilon_{0k0l}}(\pi_{0k0l} - \pi_{0k}\pi_{0l})\frac{y_k}{\pi_{0k}}\frac{y_l}{\pi_{0l}} - 2 \frac{z_k (1-z_l)}{\pi_{1k0l} + \epsilon_{1k0l}}(\pi_{1k0l} - \pi_{1k}\pi_{0l})\frac{y_k}{\pi_{1k}}\frac{y_l}{\pi_{0l}} \\\\\\
   & + \sum_{\forall l \colon \pi_{1k1l} = 0} \left( z_k \frac{y^2_k}{2\pi_{1k}} + z_l \frac{y^2_l}{\pi_{1l}}\right) + \sum_{\forall l \colon \pi_{0k0l} = 0} \left( (1-z_k) \frac{y^2_k}{2\pi_{0k}} + (1-z_l) \frac{y^2_l}{\pi_{0l}}\right)
   \Bigg]
 \end{aligned}
@@ -302,8 +287,8 @@ Alternatively, one can assume constant treatment effects and, under that assumpt
 
 $$
 \begin{aligned}
-    \widehat{\V}_{C}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[& (1 - \pi_{0i}) \pi_{0i} \left(\frac{y_{0i}}{\pi_{0i}}\right)^2 + (1 - \pi_{1i}) \pi_{1i} \left(\frac{y_{1i}}{\pi_{1i}}\right)^2 - 2 y_{1i} y_{0i} \\
-    & + \sum_{j \neq i} \Big( (\pi_{0i0j} - \pi_{0i} \pi_{0j}) \frac{y_{0i}}{\pi_{0i}} \frac{y_{0j}}{\pi_{0j}} + (\pi_{1i1j} - \pi_{1i} \pi_{1j}) \frac{y_{1i}}{\pi_{1i}} \frac{y_{1j}}{\pi_{1j}} \\
+    \widehat{\mathbb{V}}_{C}[\widehat{\tau}] = \frac{1}{N^2} \sum^N_{i=1} \Bigg[& (1 - \pi_{0i}) \pi_{0i} \left(\frac{y_{0i}}{\pi_{0i}}\right)^2 + (1 - \pi_{1i}) \pi_{1i} \left(\frac{y_{1i}}{\pi_{1i}}\right)^2 - 2 y_{1i} y_{0i} \\\\\\
+    & + \sum_{j \neq i} \Big( (\pi_{0i0j} - \pi_{0i} \pi_{0j}) \frac{y_{0i}}{\pi_{0i}} \frac{y_{0j}}{\pi_{0j}} + (\pi_{1i1j} - \pi_{1i} \pi_{1j}) \frac{y_{1i}}{\pi_{1i}} \frac{y_{1j}}{\pi_{1j}} \\\\\\
     &- 2 (\pi_{1i0j} - \pi_{1i} \pi_{0j}) \frac{y_{1i}}{\pi_{1i}} \frac{y_{0j}}{\pi_{0j}}
   \Big)\Bigg]
 \end{aligned}
@@ -313,7 +298,7 @@ $$
 
 Theory on hypothesis testing with the Horvitz-Thompson estimator is yet to be developed. We rely on a normal approximation and construct confidence intervals in the following way:
 \[
-\mathrm{CI}^{1-\alpha} = \left(\widehat{\tau} + z_{\alpha/2} \sqrt{\widehat{\V}[\widehat{\tau}]}, \widehat{\tau} + z_{1 - \alpha/2} \sqrt{\widehat{\V}[\widehat{\tau}]}\right)
+\mathrm{CI}^{1-\alpha} = \left(\widehat{\tau} + z_{\alpha/2} \sqrt{\widehat{\mathbb{V}}[\widehat{\tau}]}, \widehat{\tau} + z_{1 - \alpha/2} \sqrt{\widehat{\mathbb{V}}[\widehat{\tau}]}\right)
 \]
 
 The associated p-values for a two-sided null hypothesis test are computed using a normal disribution and the aforementioned significance level $\alpha$.


### PR DESCRIPTION
Fixed the math in the vignettes; refs still broken.

Tried to emulate these refs here(https://cran.rstudio.com/web/packages/ggmcmc/vignettes/using_ggmcmc.html) using the YAML and bib set up they use, but to no avail.