### PR TITLE
Fix lin variable name; closes #121

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,8 @@ Suggests:
     randomizr (>= 0.8),
     knitr,
     rmarkdown,
-    margins
+    margins,
+    prediction
 Enhances: broom, texreg
 VignetteBuilder: knitr
 Additional_repositories: http://r.declaredesign.org

--- a/R/estimatr_lm_lin.R
+++ b/R/estimatr_lm_lin.R
@@ -270,7 +270,7 @@ lm_lin <- function(formula,
   original_covar_names <- colnames(demeaned_covars)
 
   # Change name of centered covariates to end in bar
-  colnames(demeaned_covars) <- paste0(colnames(demeaned_covars), "_bar")
+  colnames(demeaned_covars) <- paste0(colnames(demeaned_covars), "_c")
 
   n_treat_cols <- ncol(treatment)
   n_covars <- ncol(demeaned_covars)

--- a/tests/testthat/test-lm-lin.R
+++ b/tests/testthat/test-lm-lin.R
@@ -73,10 +73,10 @@ test_that("Test LM Lin", {
     NA
   )
 
-  dat$X1_bar <- dat$X1 - mean(dat$X1)
-  dat$X2_bar <- dat$X2 - mean(dat$X2)
+  dat$X1_c <- dat$X1 - mean(dat$X1)
+  dat$X2_c <- dat$X2 - mean(dat$X2)
 
-  lm_rob_out <- lm_robust(Y ~ Z + Z * X1_bar + Z * X2_bar, data = dat)
+  lm_rob_out <- lm_robust(Y ~ Z + Z * X1_c + Z * X2_c, data = dat)
 
   expect_identical(
     tidy(lm_lin_out),
@@ -85,7 +85,7 @@ test_that("Test LM Lin", {
 
   expect_equivalent(
     lm_lin_out$coefficients,
-    lm(Y ~ Z + Z * X1_bar + Z * X2_bar, data = dat)$coefficients
+    lm(Y ~ Z + Z * X1_c + Z * X2_c, data = dat)$coefficients
   )
 
 
@@ -127,7 +127,7 @@ test_that("Test LM Lin", {
       tidy(fact_mult_out)[, -1]
     )
 
-    rob_fact_mult_out <- lm_robust(Y ~ factor(Z_mult) * X1_bar + factor(Z_mult) * X2_bar, data = dat)
+    rob_fact_mult_out <- lm_robust(Y ~ factor(Z_mult) * X1_c + factor(Z_mult) * X2_c, data = dat)
 
     expect_identical(
       tidy(fact_mult_out),
@@ -148,8 +148,8 @@ test_that("Test LM Lin", {
 
   ## Works with missing data in treatment
   dat$Z[23] <- NA
-  dat$X1_bar <- dat$X1 - mean(dat$X1[-23])
-  dat$X2_bar <- dat$X2 - mean(dat$X2[-23])
+  dat$X1_c <- dat$X1 - mean(dat$X1[-23])
+  dat$X2_c <- dat$X2 - mean(dat$X2[-23])
 
   expect_equal(
     tidy(lm_lin(
@@ -158,7 +158,7 @@ test_that("Test LM Lin", {
       data = dat
     )),
     tidy(lm_robust(
-      Y ~ Z + Z * X1_bar + Z * X2_bar,
+      Y ~ Z + Z * X1_c + Z * X2_c,
       data = dat
     ))
   )
@@ -172,7 +172,7 @@ test_that("Test LM Lin", {
       clusters = cluster
     )),
     tidy(lm_robust(
-      Y ~ Z + Z * X1_bar + Z * X2_bar,
+      Y ~ Z + Z * X1_c + Z * X2_c,
       data = dat,
       clusters = cluster
     ))
@@ -180,8 +180,8 @@ test_that("Test LM Lin", {
 
   ## Test that it works with subset
   keep <- setdiff(which(dat$Y > 0), 23)
-  dat$X1_bar <- dat$X1 - mean(dat$X1[keep])
-  dat$X2_bar <- dat$X2 - mean(dat$X2[keep])
+  dat$X1_c <- dat$X1 - mean(dat$X1[keep])
+  dat$X2_c <- dat$X2 - mean(dat$X2[keep])
 
   expect_equal(
     tidy(lm_lin(
@@ -192,7 +192,7 @@ test_that("Test LM Lin", {
       subset = Y > 0
     )),
     tidy(lm_robust(
-      Y ~ Z + Z * X1_bar + Z * X2_bar,
+      Y ~ Z + Z * X1_c + Z * X2_c,
       data = dat,
       clusters = cluster,
       subset = Y > 0
@@ -208,8 +208,8 @@ test_that("Test LM Lin", {
     cluster = sample(1:10, size = 100, replace = T)
   )
 
-  dat$X1_bar <- dat$X1 - mean(dat$X1)
-  dat$X21_bar <- as.numeric(dat$X2 == 1) - mean(dat$X2 == 1)
+  dat$X1_c <- dat$X1 - mean(dat$X1)
+  dat$X21_c <- as.numeric(dat$X2 == 1) - mean(dat$X2 == 1)
 
   expect_equivalent(
     tidy(lm_lin(
@@ -219,7 +219,7 @@ test_that("Test LM Lin", {
       clusters = cluster
     )),
     tidy(lm_robust(
-      Y ~ treat + treat * X1_bar + treat * X21_bar,
+      Y ~ treat + treat * X1_c + treat * X21_c,
       data = dat,
       clusters = cluster
     ))
@@ -232,7 +232,7 @@ test_that("Test LM Lin", {
     replace = T
   ))
   ## for lm_robust
-  dat$X2_bar <-
+  dat$X2_c <-
     as.numeric(dat$X2 == "This is a level") - mean(dat$X2 == "This is a level")
 
   ## Names will differ
@@ -247,7 +247,7 @@ test_that("Test LM Lin", {
     )[, -1],
     tidy(
       lm_robust(
-        Y ~ treat + treat * X1_bar + treat * X2_bar,
+        Y ~ treat + treat * X1_c + treat * X2_c,
         data = dat,
         clusters = cluster
       )
@@ -256,8 +256,8 @@ test_that("Test LM Lin", {
 
   ## Works with missingness on cluster
   dat$cluster[40] <- NA
-  dat$X1_bar <- dat$X1 - mean(dat$X1[-40])
-  dat$X2_bar <-
+  dat$X1_c <- dat$X1 - mean(dat$X1[-40])
+  dat$X2_c <-
     as.numeric(dat$X2 == "This is a level") - mean(dat$X2[-40] == "This is a level")
 
   expect_warning(
@@ -272,7 +272,7 @@ test_that("Test LM Lin", {
 
   expect_warning(
     rob_out <- lm_robust(
-      Y ~ treat + treat * X1_bar + treat * X2_bar,
+      Y ~ treat + treat * X1_c + treat * X2_c,
       data = dat,
       clusters = cluster
     ),
@@ -308,6 +308,6 @@ test_that("Test LM Lin", {
   lmlo <- lm_lin(Y ~ z + 0, ~X1, data = dat)
   expect_equal(
     lmlo$coefficient_name,
-    c("z", "X1_bar", "z:X1_bar")
+    c("z", "X1_c", "z:X1_c")
   )
 })

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -133,8 +133,8 @@ mar_int <- margins(lmout_int, vce = "delta")
 summary(mar_int)
 
 library(prediction)
-prediction(mar_int)
-prediction(mar_int, at = list(x = c(-0.5, 0.5)))
+prediction(lmout_int)
+prediction(lmout_int, at = list(x = c(-0.5, 0.5)))
 ```
 
 Users who want their regression output in LaTeX or HTML can use the [`texreg`](https://github.com/leifeld/texreg) package, which we extend for the output of both the `lm_robust()` and `lm_lin()` functions.

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -1,5 +1,5 @@
 ---
-title: 'Getting started using estimatr'
+title: "Getting started using estimatr"
 author: "Luke Sonnet"
 output:
   html_document:

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -123,7 +123,7 @@ tidy(lmout_stata)
 knitr::kable(tidy(lmout_stata))
 ```
 
-Furthermore, users can take advantage of the [`margins`](https://github.com/leeper/margins) package to get marginal effects, average marginal effects and their standard errors, and more.
+Furthermore, users can take advantage of the [`margins`](https://github.com/leeper/margins) package to get marginal effects, average marginal effects and their standard errors, and more. Similarly, the [`prediction`](https://github.com/leeper/prediction) package from the same author also provides a suite of software for different kinds of predictions.
 
 ```{r margins, echo=TRUE}
 library(margins)
@@ -131,6 +131,10 @@ library(margins)
 lmout_int <- lm_robust(y ~ x * z, data = dat)
 mar_int <- margins(lmout_int, vce = "delta")
 summary(mar_int)
+
+library(prediction)
+prediction(mar_int)
+prediction(mar_int, at = list(x = c(-0.5, 0.5)))
 ```
 
 Users who want their regression output in LaTeX or HTML can use the [`texreg`](https://github.com/leifeld/texreg) package, which we extend for the output of both the `lm_robust()` and `lm_lin()` functions.

--- a/vignettes/technical-notes.Rmd
+++ b/vignettes/technical-notes.Rmd
@@ -1,10 +1,10 @@
 ---
 title: "Technical notes for estimatr"
 author: "Luke Sonnet"
-link-citations: yes
 output:
   html_document:
     df_print: paged
+link-citations: yes
 bibliography: estimatr.bib
 vignette: |
   %\VignetteIndexEntry{Technical notes for estimatr}
@@ -139,10 +139,10 @@ y_i = \tau z_i + \mathbf{\beta}^\top \mathbf{x}_i + \epsilon_i
 with the following model
 
 \[
-y_i = \tau z_i + \mathbf{\beta}^\top \widetilde{\mathbf{x}}_i  + \mathbf{\gamma}^\top \widetilde{\mathbf{x}}_i z_i + \epsilon_i
+y_i = \tau z_i + \mathbf{\beta}^\top \mathbf{x}^c_i  + \mathbf{\gamma}^\top \mathbf{x}^c_i z_i + \epsilon_i
 \]
 
-where $\widetilde{\mathbf{x}}_i$ is a vector of pre-treatment covariates for unit $i$ that have been centered to have mean zero and $z_i$ is an indicator for the treatment group. @lin2013 proposed this estimator in response to the critique by @freedman2008 that using regression to adjust for pre-treatment covariates could bias estimates of treatment effects.
+where $\mathbf{x}^c_i$ is a vector of pre-treatment covariates for unit $i$ that have been centered to have mean zero and $z_i$ is an indicator for the treatment group. @lin2013 proposed this estimator in response to the critique by @freedman2008 that using regression to adjust for pre-treatment covariates could bias estimates of treatment effects.
 
 The estimator `lm_lin` also works for multi-valued treatments by creating a full set of dummies for each treatment level and interacting each with the centered pre-treatment covariates. The rest of the options for the function and corresponding estimation is identical to [`lm_robust`](#lm_robust).
 


### PR DESCRIPTION
Changes "_bar" variable suffix to "_c" for centered pre-treatment covariates.

Makes according changes in tests and in vignette.

Also demonstrates leeper/prediction usage in getting started.