### PR TITLE
Make tweaks for CRAN

### DIFF
--- a/src/lm_robust_helper.cpp
+++ b/src/lm_robust_helper.cpp
@@ -15,16 +15,16 @@ Eigen::MatrixXd AtA(const Eigen::MatrixXd& A) {
 
 // [[Rcpp::export]]
 List lm_solver(Eigen::Map<Eigen::MatrixXd>& Xfull,
-                const Eigen::Map<Eigen::VectorXd>& y,
-                const Rcpp::Nullable<Rcpp::NumericMatrix> & Xunweighted,
-                const Rcpp::Nullable<Rcpp::NumericVector> & weight,
-                const double & weight_mean,
-                const Rcpp::Nullable<Rcpp::IntegerVector> & cluster,
-                const int & J,
-                const bool & ci,
-                const String type,
-                const std::vector<bool> & which_covs,
-                const bool& try_cholesky) {
+               const Eigen::Map<Eigen::VectorXd>& y,
+               const Rcpp::Nullable<Rcpp::NumericMatrix> & Xunweighted,
+               const Rcpp::Nullable<Rcpp::NumericVector> & weight,
+               const double & weight_mean,
+               const Rcpp::Nullable<Rcpp::IntegerVector> & cluster,
+               const int & J,
+               const bool & ci,
+               const String type,
+               const std::vector<bool> & which_covs,
+               const bool& try_cholesky) {
 
   const int n(Xfull.rows()), p(Xfull.cols());
   int r = p;
@@ -33,7 +33,7 @@ List lm_solver(Eigen::Map<Eigen::MatrixXd>& Xfull,
   Eigen::VectorXd beta_out(Eigen::VectorXd::Constant(p, ::NA_REAL));
 
 
-  bool do_qr = try_cholesky;
+  bool do_qr = !try_cholesky;
   if (try_cholesky) {
     const Eigen::LLT<Eigen::MatrixXd> llt(Xfullt*Xfull);
 
@@ -114,7 +114,7 @@ List lm_solver(Eigen::Map<Eigen::MatrixXd>& Xfull,
   Eigen::MatrixXd Xoriginalfull(n, p);
   Eigen::MatrixXd X(n, r);
   Eigen::VectorXd beta_hat(r);
-  Eigen::ArrayXd weights;
+  Eigen::ArrayXd weights(n);
   bool weighted = Xunweighted.isNotNull();
   if (weighted) {
     weights = Rcpp::as<Eigen::Map<Eigen::ArrayXd> >(weight);
@@ -154,12 +154,12 @@ List lm_solver(Eigen::Map<Eigen::MatrixXd>& Xfull,
   // Rcout << "Xoriginal:" << Xoriginal << std::endl << std::endl;
   // Rcout << "beta_hat:" << beta_hat << std::endl << std::endl;
 
-  Eigen::VectorXd dof(r);
-  Eigen::VectorXd ei;
-  double s2;
+  Eigen::VectorXd dof = Eigen::VectorXd::Constant(r, -99.0);
+  Eigen::VectorXd ei = Eigen::VectorXd::Constant(n, -99.0);
+  double s2 = -99.0;
 
   // Standard error calculations
-  if(type != "none"){
+  if (type != "none"){
 
     // residuals
     ei = y - X * beta_hat;
@@ -206,187 +206,187 @@ List lm_solver(Eigen::Map<Eigen::MatrixXd>& Xfull,
 
     } else if ( (type == "stata") || (type == "CR2") || (type == "CR0") ) {
 
-     Eigen::Map<Eigen::ArrayXi> clusters = Rcpp::as<Eigen::Map<Eigen::ArrayXi> >(cluster);
+      Eigen::Map<Eigen::ArrayXi> clusters = Rcpp::as<Eigen::Map<Eigen::ArrayXi> >(cluster);
 
-     // Following code implements the clubSandwich package CR2 estimatr found here:
-     // https://github.com/jepusto/clubSandwich
-     // Much of the code is also a translation/adaptation from the R code in that package
-     if (type == "CR2") {
+      // Following code implements the clubSandwich package CR2 estimatr found here:
+      // https://github.com/jepusto/clubSandwich
+      // Much of the code is also a translation/adaptation from the R code in that package
+      if (type == "CR2") {
 
-       Eigen::VectorXd cr2_eis;
-       if (weighted) {
-         // Instead of having X and Xt be weighted by sqrt(W), this has them weighted by W
-         X.array().colwise() *= weights;
-         // Unweighted residuals
-         cr2_eis = y.array() / weights - (Xoriginal * beta_hat).array();
-       } else {
-         cr2_eis = ei;
-       }
+        Eigen::VectorXd cr2_eis;
+        if (weighted) {
+          // Instead of having X and Xt be weighted by sqrt(W), this has them weighted by W
+          X.array().colwise() *= weights;
+          // Unweighted residuals
+          cr2_eis = y.array() / weights - (Xoriginal * beta_hat).array();
+        } else {
+          cr2_eis = ei;
+        }
 
-       Eigen::MatrixXd tutX(J, r);
+        Eigen::MatrixXd tutX(J, r);
 
-       // used for the dof corrction
-       Eigen::MatrixXd H1s(r, r*J);
-       Eigen::MatrixXd H2s(r, r*J);
-       Eigen::MatrixXd H3s(r, r*J);
-       Eigen::MatrixXd P_diags(r, J);
+        // used for the dof corrction
+        Eigen::MatrixXd H1s(r, r*J);
+        Eigen::MatrixXd H2s(r, r*J);
+        Eigen::MatrixXd H3s(r, r*J);
+        Eigen::MatrixXd P_diags(r, J);
 
-       Eigen::MatrixXd M_U_ct = XtX_inv.llt().matrixL();
+        Eigen::MatrixXd M_U_ct = XtX_inv.llt().matrixL();
 
-       Eigen::MatrixXd MUWTWUM = XtX_inv * X.transpose() * X * XtX_inv;
-       Eigen::MatrixXd Omega_ct = MUWTWUM.llt().matrixL();
+        Eigen::MatrixXd MUWTWUM = XtX_inv * X.transpose() * X * XtX_inv;
+        Eigen::MatrixXd Omega_ct = MUWTWUM.llt().matrixL();
 
-       // Rcout << Omega_ct << std::endl;
+        // Rcout << Omega_ct << std::endl;
 
-       // Rcout << "SIZES" << std::endl;
-       // Rcout << "X: " << X.rows() << "x" << X.cols() << std::endl;
-       // Rcout << "Xoriginal: " << Xoriginal.rows() << "x" << Xoriginal.cols() << std::endl;
-       // Rcout << "XtX_inv: " << XtX_inv.rows() << "x" << XtX_inv.cols() << std::endl;
+        // Rcout << "SIZES" << std::endl;
+        // Rcout << "X: " << X.rows() << "x" << X.cols() << std::endl;
+        // Rcout << "Xoriginal: " << Xoriginal.rows() << "x" << Xoriginal.cols() << std::endl;
+        // Rcout << "XtX_inv: " << XtX_inv.rows() << "x" << XtX_inv.cols() << std::endl;
 
-       double current_cluster = clusters(0);
-       int j = 0;
-       int start_pos = 0;
-       int len = 1;
+        double current_cluster = clusters(0);
+        int j = 0;
+        int start_pos = 0;
+        int len = 1;
 
-       // iterate over unique cluster values
-       for(int i = 1; i <= n; ++i){
+        // iterate over unique cluster values
+        for(int i = 1; i <= n; ++i){
 
-         //Rcout << "clusters(i): " << clusters(i) << std::endl;
-         if ((i == n) || (clusters(i) != current_cluster)) {
-           // Rcout << "Current cluster: " << current_cluster << std::endl;
-           // Rcout << "Starting position: " << start_pos << std::endl;
-           // Rcout << "len: " << len << std::endl << std::endl;
-           // Rcout <<  X.transpose().block(0, start_pos, r, len) << std::endl << std::endl;
+          //Rcout << "clusters(i): " << clusters(i) << std::endl;
+          if ((i == n) || (clusters(i) != current_cluster)) {
+            // Rcout << "Current cluster: " << current_cluster << std::endl;
+            // Rcout << "Starting position: " << start_pos << std::endl;
+            // Rcout << "len: " << len << std::endl << std::endl;
+            // Rcout <<  X.transpose().block(0, start_pos, r, len) << std::endl << std::endl;
 
-           // Rcout <<  X.transpose().block(0, start_pos, r, len) << std::endl << std::endl;
+            // Rcout <<  X.transpose().block(0, start_pos, r, len) << std::endl << std::endl;
 
-           // TODO H should be symmetric, shouldn't need to transpose
-           Eigen::MatrixXd H = Xoriginal.block(start_pos, 0, len, r) * XtX_inv * X.block(start_pos, 0, len, r).transpose();
+            // TODO H should be symmetric, shouldn't need to transpose
+            Eigen::MatrixXd H = Xoriginal.block(start_pos, 0, len, r) * XtX_inv * X.block(start_pos, 0, len, r).transpose();
 
-           // Rcout << "H: " << H << std::endl;
+            // Rcout << "H: " << H << std::endl;
 
-           // Code from clubSandwich
-           // uwTwu <- Map(function(uw, th) uw %*% th %*% t(uw),
-           //             uw = UW_list, th = Theta_list)
-           // MUWTWUM <- M_U %*% Reduce("+", uwTwu) %*% M_U
+            // Code from clubSandwich
+            // uwTwu <- Map(function(uw, th) uw %*% th %*% t(uw),
+            //             uw = UW_list, th = Theta_list)
+            // MUWTWUM <- M_U %*% Reduce("+", uwTwu) %*% M_U
 
-           //(thet - h %*% thet - thet %*% t(h) + u %*% MUWTWUM %*% t(u))
+            //(thet - h %*% thet - thet %*% t(h) + u %*% MUWTWUM %*% t(u))
 
-           // A' W R in clubSand notation
-           // Rcout << "At_WX: " << (Eigen::MatrixXd::Identity(len, len) - H) - H.transpose() + Xoriginal.block(start_pos, 0, len, r) * MUWTWUM * Xoriginal.block(start_pos, 0, len, r).transpose() << std::endl;
-           // Rcout << "MUWTWUM: " << MUWTWUM << std::endl;
+            // A' W R in clubSand notation
+            // Rcout << "At_WX: " << (Eigen::MatrixXd::Identity(len, len) - H) - H.transpose() + Xoriginal.block(start_pos, 0, len, r) * MUWTWUM * Xoriginal.block(start_pos, 0, len, r).transpose() << std::endl;
+            // Rcout << "MUWTWUM: " << MUWTWUM << std::endl;
 
-           Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> At_WX(
-               (Eigen::MatrixXd::Identity(len, len) - H) - H +
-                 Xoriginal.block(start_pos, 0, len, r) * MUWTWUM * Xoriginal.block(start_pos, 0, len, r).transpose()
-           );
+            Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> At_WX(
+                (Eigen::MatrixXd::Identity(len, len) - H) - H +
+                  Xoriginal.block(start_pos, 0, len, r) * MUWTWUM * Xoriginal.block(start_pos, 0, len, r).transpose()
+            );
 
-           Eigen::VectorXd eigvals = At_WX.eigenvalues();
-           for (int m = 0; m < eigvals.size(); ++m) {
-             if (eigvals(m) > std::pow(10.0, -12.0)) {
-               eigvals(m) = 1.0 / std::sqrt(eigvals(m));
-             } else {
-               eigvals(m) = 0;
-             }
-           }
+            Eigen::VectorXd eigvals = At_WX.eigenvalues();
+            for (int m = 0; m < eigvals.size(); ++m) {
+              if (eigvals(m) > std::pow(10.0, -12.0)) {
+                eigvals(m) = 1.0 / std::sqrt(eigvals(m));
+              } else {
+                eigvals(m) = 0;
+              }
+            }
 
-           // Rcout << "Xblock: " << X.block(start_pos, 0, len, r) << std::endl;
-           // Rcout << "At_WX_inv: " << At_WX.operatorInverseSqrt() << std::endl;
+            // Rcout << "Xblock: " << X.block(start_pos, 0, len, r) << std::endl;
+            // Rcout << "At_WX_inv: " << At_WX.operatorInverseSqrt() << std::endl;
 
-           // TODO mimic tol in arma implementation
-           //Eigen::MatrixXd At_WX_inv = At_WX.operatorInverseSqrt() * X.block(start_pos, 0, len, r);
-           Eigen::MatrixXd At_WX_inv =
-             ((At_WX.eigenvectors() * eigvals.asDiagonal()) * At_WX.eigenvectors().transpose())
-             * X.block(start_pos, 0, len, r);
+            // TODO mimic tol in arma implementation
+            //Eigen::MatrixXd At_WX_inv = At_WX.operatorInverseSqrt() * X.block(start_pos, 0, len, r);
+            Eigen::MatrixXd At_WX_inv =
+              ((At_WX.eigenvectors() * eigvals.asDiagonal()) * At_WX.eigenvectors().transpose())
+              * X.block(start_pos, 0, len, r);
 
-           if (ci) {
+            if (ci) {
 
-             Eigen::MatrixXd ME(r, len);
-             if (weighted) {
-               ME = (XtX_inv / weight_mean) * At_WX_inv.transpose();
-             } else {
-               ME = XtX_inv * At_WX_inv.transpose();
-             }
+              Eigen::MatrixXd ME(r, len);
+              if (weighted) {
+                ME = (XtX_inv / weight_mean) * At_WX_inv.transpose();
+              } else {
+                ME = XtX_inv * At_WX_inv.transpose();
+              }
 
-             P_diags.col(j) = ME.array().pow(2).rowwise().sum();
+              P_diags.col(j) = ME.array().pow(2).rowwise().sum();
 
-             Eigen::MatrixXd MEU = ME * Xoriginal.block(start_pos, 0, len, r);
+              Eigen::MatrixXd MEU = ME * Xoriginal.block(start_pos, 0, len, r);
 
-             int p_pos = j*r;
-             // Rcout << "p_pos: " << p_pos << std::endl;
-             H1s.block(0, p_pos, r, r) = MEU * M_U_ct;
-             H2s.block(0, p_pos, r, r) = ME * X.block(start_pos, 0, len, r) * M_U_ct;
-             H3s.block(0, p_pos, r, r) = MEU * Omega_ct;
-           }
+              int p_pos = j*r;
+              // Rcout << "p_pos: " << p_pos << std::endl;
+              H1s.block(0, p_pos, r, r) = MEU * M_U_ct;
+              H2s.block(0, p_pos, r, r) = ME * X.block(start_pos, 0, len, r) * M_U_ct;
+              H3s.block(0, p_pos, r, r) = MEU * Omega_ct;
+            }
 
-           // t(cr2_eis) %*% (I - P_ss)^{-1/2} %*% Xj
-           // each ro  w is the contribution of the cluster to the meat
-           // Below use  t(tutX) %*% tutX to sum contributions across clusters
+            // t(cr2_eis) %*% (I - P_ss)^{-1/2} %*% Xj
+            // each ro  w is the contribution of the cluster to the meat
+            // Below use  t(tutX) %*% tutX to sum contributions across clusters
 
-           // Rcout << "At_WX_inv: " << At_WX_inv << std::endl;
-           // Rcout << "cr2_eis: " << cr2_eis.segment(start_pos, len).transpose() << std::endl;
-           tutX.row(j) = cr2_eis.segment(start_pos, len).transpose() * At_WX_inv;
+            // Rcout << "At_WX_inv: " << At_WX_inv << std::endl;
+            // Rcout << "cr2_eis: " << cr2_eis.segment(start_pos, len).transpose() << std::endl;
+            tutX.row(j) = cr2_eis.segment(start_pos, len).transpose() * At_WX_inv;
 
-           if (i < n) {
-             current_cluster = clusters(i);
-             len = 1;
-             start_pos = i;
-             j++;
-           }
-
-
-         } else {
-           len++;
-           continue;
-         }
-
-       }
+            if (i < n) {
+              current_cluster = clusters(i);
+              len = 1;
+              start_pos = i;
+              j++;
+            }
 
 
-       // Rcout << "XtX_inv: " << std::endl << XtX_inv << std::endl;
-       // Rcout << "tutX: " << std::endl << tutX << std::endl;
+          } else {
+            len++;
+            continue;
+          }
 
-       Vcov_hat = XtX_inv * (tutX.transpose() * tutX) * XtX_inv;
+        }
 
-       // Rcout << "H1s" << std::endl << std::endl;
-       // Rcout << H1s << std::endl << std::endl;
-       // Rcout << "H2s" << std::endl << std::endl;
-       // Rcout << H2s << std::endl << std::endl;
-       // Rcout << "H3s" << std::endl << std::endl;
-       // Rcout << H3s << std::endl << std::endl;
 
-       if (ci) {
-         dof.fill(-99);
-         int k = 0;
-         for(int j = 0; j < p; j++){
-           // only compute for covars that we need the DoF for
-           if (!std::isnan(beta_out(j))) {
-             if (which_covs[j]) {
+        // Rcout << "XtX_inv: " << std::endl << XtX_inv << std::endl;
+        // Rcout << "tutX: " << std::endl << tutX << std::endl;
 
-               Eigen::MatrixXd H1t = H1s.row(k);
-               Eigen::MatrixXd H2t = H2s.row(k);
-               Eigen::MatrixXd H3t = H3s.row(k);
-               // Rcout << H1t << std::endl<< std::endl;
+        Vcov_hat = XtX_inv * (tutX.transpose() * tutX) * XtX_inv;
 
-               H1t.resize(r, J);
-               H2t.resize(r, J);
-               H3t.resize(r, J);
+        // Rcout << "H1s" << std::endl << std::endl;
+        // Rcout << H1s << std::endl << std::endl;
+        // Rcout << "H2s" << std::endl << std::endl;
+        // Rcout << H2s << std::endl << std::endl;
+        // Rcout << "H3s" << std::endl << std::endl;
+        // Rcout << H3s << std::endl << std::endl;
 
-               // Rcout << H1t << std::endl<< std::endl;
+        if (ci) {
+          dof.fill(-99);
+          int k = 0;
+          for(int j = 0; j < p; j++){
+            // only compute for covars that we need the DoF for
+            if (!std::isnan(beta_out(j))) {
+              if (which_covs[j]) {
 
-               Eigen::MatrixXd uf = H1t.transpose() * H2t;
-               Eigen::MatrixXd P_row = P_diags.row(k).asDiagonal();
-               Eigen::MatrixXd P_array = (H3t.transpose()*H3t - uf - uf.transpose()) + P_row;
-               // Rcout << "P_array: " << P_array << std::endl;
+                Eigen::MatrixXd H1t = H1s.row(k);
+                Eigen::MatrixXd H2t = H2s.row(k);
+                Eigen::MatrixXd H3t = H3s.row(k);
+                // Rcout << H1t << std::endl<< std::endl;
 
-               // Rcout << std::pow(P_array.trace(), 2) << " and " << P_array.array().pow(2).sum() << std::endl;
-               dof(k) = std::pow(P_array.trace(), 2) / P_array.array().pow(2).sum();
-             }
-             k++;
-           }
-         }
-       }
-     } else if ((type == "stata") || (type == "CR0")) {
+                H1t.resize(r, J);
+                H2t.resize(r, J);
+                H3t.resize(r, J);
+
+                // Rcout << H1t << std::endl<< std::endl;
+
+                Eigen::MatrixXd uf = H1t.transpose() * H2t;
+                Eigen::MatrixXd P_row = P_diags.row(k).asDiagonal();
+                Eigen::MatrixXd P_array = (H3t.transpose()*H3t - uf - uf.transpose()) + P_row;
+                // Rcout << "P_array: " << P_array << std::endl;
+
+                // Rcout << std::pow(P_array.trace(), 2) << " and " << P_array.array().pow(2).sum() << std::endl;
+                dof(k) = std::pow(P_array.trace(), 2) / P_array.array().pow(2).sum();
+              }
+              k++;
+            }
+          }
+        }
+      } else if ((type == "stata") || (type == "CR0")) {
 
         Eigen::MatrixXd XteetX = Eigen::MatrixXd::Zero(r, r);
         double current_cluster = clusters(0);
@@ -439,7 +439,7 @@ List lm_solver(Eigen::Map<Eigen::MatrixXd>& Xfull,
         dof.fill(J - 1);
 
         //Rcpp::Rcout << 'here' << std::endl;
-     }
+      }
     }
   }
 

--- a/tests/testthat/test-lm-lin.R
+++ b/tests/testthat/test-lm-lin.R
@@ -78,7 +78,7 @@ test_that("Test LM Lin", {
 
   lm_rob_out <- lm_robust(Y ~ Z + Z * X1_c + Z * X2_c, data = dat)
 
-  expect_identical(
+  expect_equal(
     tidy(lm_lin_out),
     tidy(lm_rob_out)
   )
@@ -122,20 +122,20 @@ test_that("Test LM Lin", {
       data = dat
     )
 
-    expect_identical(
+    expect_equal(
       tidy(mult_out)[, -1],
       tidy(fact_mult_out)[, -1]
     )
 
     rob_fact_mult_out <- lm_robust(Y ~ factor(Z_mult) * X1_c + factor(Z_mult) * X2_c, data = dat)
 
-    expect_identical(
+    expect_equal(
       tidy(fact_mult_out),
       tidy(rob_fact_mult_out)
     )
 
     # Also works with no intercept!
-    expect_identical(
+    expect_equal(
       tidy(noint_mult_out)[, -1],
       tidy(noint_fact_mult_out)[, -1]
     )
@@ -164,7 +164,7 @@ test_that("Test LM Lin", {
   )
 
   ## Test cluster passes through
-  expect_identical(
+  expect_equal(
     tidy(lm_lin(
       Y ~ Z,
       covariates = ~ X1 + X2,

--- a/tests/testthat/test-lm-robust_margins.R
+++ b/tests/testthat/test-lm-robust_margins.R
@@ -27,16 +27,20 @@ test_that("lm robust can work with margins",{
   lmr_sum_marg <- summary(margins::margins(lmr, vce = "delta"))
 
   # Close enough with HC2?
-  expect_true(
-    max(lm_sum_marg[, mv] - lmr_sum_marg[, mv]) < 2e-05
+  expect_equal(
+    lm_sum_marg[, mv],
+    lmr_sum_marg[, mv],
+    tolerance = 0.01
   )
 
   # Close with classical
   lmr_class <- lm_robust(mpg ~ cyl * hp + wt, data = mtcars, se_type = "classical")
   lmrc <- summary(margins(lmr_class, vce = "delta"))
   lmc <- summary(margins(x, vce = "delta"))
-  expect_true(
-    max(lmc[, mv] - lmrc[, mv]) < 2e-05
+  expect_equal(
+    lmc[, mv],
+    lmrc[, mv],
+    tolerance = 0.01
   )
 
   # Works with other vce


### PR DESCRIPTION
There were some "deep" CRAN errors we needed to resolve that you can see here: https://cran.r-project.org/web/checks/check_results_estimatr.html

1. Tests failed without Long Doubles (https://www.stats.ox.ac.uk/pub/bdr/noLD/estimatr.out). They were not identical but rather equal, so I just changed the test.
2. Uninitialized values (the degrees of freedom, residuals, and residual variance in `lm_robust_helper.cpp` were being used and returned to the R wrapper code and were causing errors in Valgrind. I now initialize these values and tested all of the test files one by one using valgrind and there are no more errors.
3. Solaris errored on a test that `expect_equal` the max diff of two `margins` was less than < 2e05. I changed the test to `expect_equals` with a tolerance of 0.01. I have no way to test this since rhub's Solaris platform apparently cannot compile RcppEigen files (and I'm not sure if I can fix this). See r-hub/rhub/issues/109.

I think if this passes, we might as well try to resubmit and see what they say?

Oh, I also got rid of my silly way to handle if the cholesky decomposition failed that relied on catching my own error. Logic should be much cleaner now.