### PR TITLE
Fix transposed hat messing up weighted CR2 variance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ r_packages:
 - broom
 - ggplot2
 - texreg
+- clubSandwich
 
 after_success:
 - Rscript -e DDtools::after_build

--- a/src/lm_robust_helper.cpp
+++ b/src/lm_robust_helper.cpp
@@ -277,7 +277,7 @@ List lm_solver(Eigen::Map<Eigen::MatrixXd>& Xfull,
             // Rcout << "MUWTWUM: " << MUWTWUM << std::endl;
 
             Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> At_WX(
-                (Eigen::MatrixXd::Identity(len, len) - H) - H +
+                (Eigen::MatrixXd::Identity(len, len) - H) - H.transpose() +
                   Xoriginal.block(start_pos, 0, len, r) * MUWTWUM * Xoriginal.block(start_pos, 0, len, r).transpose()
             );
 

--- a/tests/testthat/test-lm-cluster.R
+++ b/tests/testthat/test-lm-cluster.R
@@ -180,7 +180,30 @@ test_that("lm cluster se", {
   test_lm_cluster_variance(NULL)
   test_lm_cluster_variance(dat$W)
 
-  # bmlmse doesn't take into consideration weights, can't test
+
+})
+
+test_that("Clustered weighted SEs are correct", {
+  skip_if_not_installed("clubSandwich")
+
+  lm_cr2 <- lm_robust(mpg ~ hp, data = mtcars, weights = wt, clusters = cyl, se_type = "CR2")
+  lm_stata <- lm_robust(mpg ~ hp, data = mtcars, weights = wt, clusters = cyl, se_type = "stata")
+  lm_cr0 <- lm_robust(mpg ~ hp, data = mtcars, weights = wt, clusters = cyl, se_type = "CR0")
+
+  lm_o <- lm(mpg ~ hp, data = mtcars, weights = wt)
+
+  expect_equivalent(
+    vcov(lm_cr2),
+    as.matrix(clubSandwich::vcovCR(lm_o, cluster = mtcars$cyl, type = "CR2"))
+  )
+  expect_equivalent(
+    vcov(lm_cr0),
+    as.matrix(clubSandwich::vcovCR(lm_o, cluster = mtcars$cyl, type = "CR0"))
+  )
+  expect_equivalent(
+    vcov(lm_stata),
+    as.matrix(clubSandwich::vcovCR(lm_o, cluster = mtcars$cyl, type = "CR1S"))
+  )
 })
 
 test_that("lm cluster se with missingness", {


### PR DESCRIPTION
Fixes meat of CR2 variance estimator when there are weights.

Adds tests, clubSandwich to travis for tests.

This should be merged ASAP.