### PR TITLE
Fixes weighting for lm_lin and blocked difference_in_means

### DIFF
--- a/R/estimatr_difference_in_means.R
+++ b/R/estimatr_difference_in_means.R
@@ -238,7 +238,11 @@ difference_in_means <-
       stringsAsFactors = FALSE
     )
     data$cluster <- model_data$cluster
-    data$weights <- model_data$weights
+    # rescale weights for convenience
+    if (is.numeric(model_data$weights)) {
+      weight_mean <- mean(model_data$weights)
+      data$weights <- model_data$weights / weight_mean
+    }
     data$block <- model_data$block
 
     if (!is.null(data$weights) && length(unique(data$weights)) == 1
@@ -355,7 +359,7 @@ difference_in_means <-
         ## matches lm_lin, two estimates per block
         if (is.null(data$cluster)) {
           design <- "Blocked"
-          df <- N_overall - 2 * n_blocks
+          df <- nrow(data) - 2 * n_blocks
         } else {
           design <- "Block-clustered"
           # Also matches lm_lin for even sized clusters, should be conservative
@@ -520,10 +524,15 @@ difference_in_means_internal <-
       data.frame(
         coefficients = diff,
         se = se,
-        N = N,
         df = df,
         stringsAsFactors = FALSE
       )
+
+    if (is.numeric(data$weights)) {
+      return_frame$N <- sum(data$weights)
+    } else {
+      return_frame$N <- N
+    }
 
     return(return_frame)
   }

--- a/R/estimatr_difference_in_means.R
+++ b/R/estimatr_difference_in_means.R
@@ -240,8 +240,7 @@ difference_in_means <-
     data$cluster <- model_data$cluster
     # rescale weights for convenience
     if (is.numeric(model_data$weights)) {
-      weight_mean <- mean(model_data$weights)
-      data$weights <- model_data$weights / weight_mean
+      data$weights <- model_data$weights / mean(model_data$weights)
     }
     data$block <- model_data$block
 

--- a/R/estimatr_lm_lin.R
+++ b/R/estimatr_lm_lin.R
@@ -265,15 +265,10 @@ lm_lin <- function(formula,
   if (is.numeric(weights)) {
     center <- apply(demeaned_covars, 2, weighted.mean, weights)
   } else {
-    center <- TRUE
+    center <- colMeans(demeaned_covars)
   }
 
-  demeaned_covars <-
-    scale(
-      demeaned_covars,
-      center = center,
-      scale = FALSE
-    )
+  demeaned_covars <- sweep(demeaned_covars, 2, center)
 
   original_covar_names <- colnames(demeaned_covars)
 
@@ -349,7 +344,7 @@ lm_lin <- function(formula,
     formula = formula
   )
 
-  return_list[["scaled_center"]] <- attr(demeaned_covars, "scaled:center")
+  return_list[["scaled_center"]] <- center
   setNames(return_list[["scaled_center"]], original_covar_names)
 
   return_list[["call"]] <- match.call()

--- a/R/estimatr_lm_lin.R
+++ b/R/estimatr_lm_lin.R
@@ -263,9 +263,7 @@ lm_lin <- function(formula,
 
   # Choose what to center on!
   if (is.numeric(weights)) {
-    weight_mean <- mean(weights)
-    weights <- weights / weight_mean
-    center <- colMeans(demeaned_covars * weights)
+    center <- apply(demeaned_covars, 2, weighted.mean, weights)
   } else {
     center <- TRUE
   }
@@ -276,7 +274,6 @@ lm_lin <- function(formula,
       center = center,
       scale = FALSE
     )
-  print(center)
 
   original_covar_names <- colnames(demeaned_covars)
 

--- a/R/estimatr_lm_lin.R
+++ b/R/estimatr_lm_lin.R
@@ -253,16 +253,30 @@ lm_lin <- function(formula,
   # Center and interact variables
   # ----------
 
+  # Initialize as non-demeaned
+  demeaned_covars <-
+    design_matrix[
+      ,
+      setdiff(colnames(design_matrix), c(design_mat_treatment, "(Intercept)")),
+      drop = FALSE
+    ]
+
+  # Choose what to center on!
+  if (is.numeric(weights)) {
+    weight_mean <- mean(weights)
+    weights <- weights / weight_mean
+    center <- colMeans(demeaned_covars * weights)
+  } else {
+    center <- TRUE
+  }
+
   demeaned_covars <-
     scale(
-      design_matrix[
-        ,
-        setdiff(colnames(design_matrix), c(design_mat_treatment, "(Intercept)")),
-        drop = FALSE
-      ],
-      center = TRUE,
+      demeaned_covars,
+      center = center,
       scale = FALSE
     )
+  print(center)
 
   original_covar_names <- colnames(demeaned_covars)
 

--- a/tests/testthat/test-difference-in-means.R
+++ b/tests/testthat/test-difference-in-means.R
@@ -581,8 +581,6 @@ test_that("DIM matches lm_robust under certain conditions", {
   # With weights now, identical to lm_robust, HC2 by force! except for matched pairs which fails
   dat$w <- runif(nrow(dat))
 
-
-
   # simple W
   expect_equivalent(
     tidy(lm_robust(Y ~ z, data = dat, weights = w))[2, ],

--- a/tests/testthat/test-lm-lin.R
+++ b/tests/testthat/test-lm-lin.R
@@ -312,7 +312,7 @@ test_that("Test LM Lin", {
   )
 })
 
-test_that("lm_lin weights appropriately", {
+test_that("lm_lin same as sampling perspective", {
 
   # Unweighted matches sampling view
   lmo <- lm_lin(mpg ~ am, ~ hp, data = mtcars)
@@ -329,6 +329,9 @@ test_that("lm_lin weights appropriately", {
     ate,
     lmo$coefficients["am"]
   )
+})
+
+test_that("weighted lm_lin same as with one covar sampling view", {
 
   # Weighted matches (one covar)
   lmwo <- lm_lin(mpg ~ am, ~ hp, weights = wt, data = mtcars)
@@ -345,6 +348,9 @@ test_that("lm_lin weights appropriately", {
     wate,
     lmwo$coefficients["am"]
   )
+})
+
+test_that("weighted lm_lin same as with two covar sampling view", {
 
   # Weighted matches (two covars)
   lmw2o <- lm_lin(mpg ~ am, ~ hp + cyl, weights = wt, data = mtcars)

--- a/tests/testthat/test-lm-lin.R
+++ b/tests/testthat/test-lm-lin.R
@@ -311,3 +311,54 @@ test_that("Test LM Lin", {
     c("z", "X1_c", "z:X1_c")
   )
 })
+
+test_that("lm_lin weights appropriately", {
+
+  # Unweighted matches sampling view
+  lmo <- lm_lin(mpg ~ am, ~ hp, data = mtcars)
+  m_hp <- mean(mtcars$hp)
+  areg <- lm(mpg ~ hp, data = mtcars, subset = am == 1)
+  breg <- lm(mpg ~ hp, data = mtcars, subset = am == 0)
+  ate <-
+    with(mtcars[mtcars$am == 1, ],
+         mean(mpg) + (m_hp - mean(hp)) * areg$coefficients[2]) -
+    with(mtcars[mtcars$am == 0, ],
+         mean(mpg) + (m_hp - mean(hp)) * breg$coefficients[2])
+
+  expect_equivalent(
+    ate,
+    lmo$coefficients["am"]
+  )
+
+  # Weighted matches (one covar)
+  lmwo <- lm_lin(mpg ~ am, ~ hp, weights = wt, data = mtcars)
+  hp_wmean <- weighted.mean(mtcars$hp, mtcars$wt)
+  wareg <- lm(mpg ~ hp, data = mtcars, subset = am == 1, weights = wt)
+  wbreg <- lm(mpg ~ hp, data = mtcars, subset = am == 0, weights = wt)
+  wate <-
+    with(mtcars[mtcars$am == 1, ],
+         weighted.mean(mpg, wt) + (hp_wmean - weighted.mean(hp, wt)) * wareg$coefficients[2]) -
+    with(mtcars[mtcars$am == 0, ],
+         weighted.mean(mpg, wt) + (hp_wmean - weighted.mean(hp, wt)) * wbreg$coefficients[2])
+
+  expect_equivalent(
+    wate,
+    lmwo$coefficients["am"]
+  )
+
+  # Weighted matches (two covars)
+  lmw2o <- lm_lin(mpg ~ am, ~ hp + cyl, weights = wt, data = mtcars)
+  hpcyl_wmean <- apply(mtcars[, c("hp", "cyl")], 2, weighted.mean, mtcars$wt)
+  w2areg <- lm(mpg ~ hp + cyl, data = mtcars, subset = am == 1, weights = wt)
+  w2breg <- lm(mpg ~ hp + cyl, data = mtcars, subset = am == 0, weights = wt)
+  w2ate <-
+    with(mtcars[mtcars$am == 1, ],
+         weighted.mean(mpg, wt) + (hpcyl_wmean - apply(cbind(hp, cyl), 2, weighted.mean, wt)) %*% w2areg$coefficients[2:3]) -
+    with(mtcars[mtcars$am == 0, ],
+         weighted.mean(mpg, wt) + (hpcyl_wmean - apply(cbind(hp, cyl), 2, weighted.mean, wt)) %*% w2breg$coefficients[2:3])
+
+  expect_equivalent(
+    w2ate,
+    lmw2o$coefficients["am"]
+  )
+})


### PR DESCRIPTION
Previously, `lm_lin` was not demeaning covariates by the weighted mean, and was just using the simple mean (Issue #148). This has been solved.

After solving it, a test failed checking `difference_in_means` against `lm_lin` in the blocked, weighted case. This test previously passed because both were wrong in the same say!

The above problem is solved now. In `difference_in_means()` we compute the post-stratification estimator as:

```r
diff <- with(block_estimates, sum(coefficients * N / N_overall))
```

The problem was that we used `N` and `N_overall` rather than the sum of the weights in a block and the sum of all of the weights if you had a blocked, weighted specification. Now `N` and `N_overall` appropriately capture the weights.