### PR TITLE
Changes tidy output

### DIFF
--- a/R/S3_summary.R
+++ b/R/S3_summary.R
@@ -103,7 +103,7 @@ summary.horvitz_thompson <-
   }
 
 summarize_tidy <- function(object, test = "t", ...) {
-  remove_cols <- c("coefficient_name", "outcome")
+  remove_cols <- c("term", "outcome")
 
   # This is ugly SO THAT summary(fit)$coefficients returns something like lm does.
   tidy_out <- tidy(object, ...)

--- a/R/S3_tidy.R
+++ b/R/S3_tidy.R
@@ -94,17 +94,27 @@ tidy_data_frame <- function(object, digits = NULL) {
       "df"
     )
 
+  tidy_names <-
+    c(
+      "estimate",
+      "std.error",
+      "p.value",
+      "ci.lower",
+      "ci.upper",
+      "df"
+    )
+
   tidy_mat <- do.call("cbind", lapply(vec_cols, function(x) {as.vector(object[[x]])}))
   colnames(tidy_mat) <- vec_cols
   return_frame <- data.frame(
-    coefficient_name = object[["coefficient_name"]],
+    term = object[["coefficient_name"]],
     tidy_mat,
     stringsAsFactors = FALSE
   )
 
   return_frame$outcome <- rep(object[["outcome"]], each = length(object[["coefficient_name"]]))
 
-  row.names(return_frame) <- NULL
+  rownames(return_frame) <- NULL
   return(return_frame)
 }
 

--- a/R/S3_tidy.R
+++ b/R/S3_tidy.R
@@ -105,7 +105,7 @@ tidy_data_frame <- function(object, digits = NULL) {
     )
 
   tidy_mat <- do.call("cbind", lapply(vec_cols, function(x) {as.vector(object[[x]])}))
-  colnames(tidy_mat) <- vec_cols
+  colnames(tidy_mat) <- tidy_names
   return_frame <- data.frame(
     term = object[["coefficient_name"]],
     tidy_mat,

--- a/tests/testthat/test-condition1-condition2.R
+++ b/tests/testthat/test-condition1-condition2.R
@@ -36,14 +36,14 @@ test_that("Condition arguments behave as expected", {
       condition1 = 3,
       condition2 = 4,
       condition_prs = rep(0.5, nrow(dat))
-    ))[c("coefficients", "se")],
+    ))[c("estimate", "std.error")],
     tidy(horvitz_thompson(
       y ~ z,
       data = dat,
       condition1 = 4,
       condition2 = 3,
       condition_prs = rep(0.5, nrow(dat))
-    ))[c("coefficients", "se")] * c(-1, 1)
+    ))[c("estimate", "std.error")] * c(-1, 1)
   )
 
   expect_identical(
@@ -52,13 +52,13 @@ test_that("Condition arguments behave as expected", {
       data = dat,
       condition1 = 2,
       condition2 = 1
-    ))[c("coefficients", "se")],
+    ))[c("estimate", "std.error")],
     tidy(difference_in_means(
       y ~ z,
       data = dat,
       condition1 = 1,
       condition2 = 2
-    ))[c("coefficients", "se")] * c(-1, 1)
+    ))[c("estimate", "std.error")] * c(-1, 1)
   )
 
   # Errors if not specifying both

--- a/tests/testthat/test-difference-in-means.R
+++ b/tests/testthat/test-difference-in-means.R
@@ -22,7 +22,7 @@ test_that("DIM arguments parsed correctly", {
   expect_equivalent(
     as.matrix(tidy(difference_in_means(
       Y ~ Z, data = dat, ci = FALSE
-    ))[, c("p", "ci_lower", "ci_upper")]),
+    ))[, c("p.value", "ci.lower", "ci.upper")]),
     matrix(NA, nrow = 1, ncol = 3)
   )
 
@@ -78,8 +78,8 @@ test_that("DIM Blocked", {
   dim_reverse <- difference_in_means(Y ~ Z, condition1 = 1, condition2 = 0, blocks = block, data = dat)
 
   expect_equal(
-    tidy(dim_normal)[c("coefficients", "se")],
-    tidy(dim_reverse)[c("coefficients", "se")] * c(-1, 1)
+    tidy(dim_normal)[c("estimate", "std.error")],
+    tidy(dim_reverse)[c("estimate", "std.error")] * c(-1, 1)
   )
 
   difference_in_means(Y ~ Z, alpha = .05, blocks = block, data = dat)

--- a/tests/testthat/test-horvitz-thompson.R
+++ b/tests/testthat/test-horvitz-thompson.R
@@ -331,7 +331,7 @@ test_that("Horvitz-Thompson properly checks arguments and data", {
 
   ht_o <- horvitz_thompson(y ~ z, data = dat, ci = FALSE)
   expect_equivalent(
-    as.matrix(tidy(horvitz_thompson(y ~ z, data = dat, ci = FALSE))[, c("p", "ci_lower", "ci_upper")]),
+    as.matrix(tidy(horvitz_thompson(y ~ z, data = dat, ci = FALSE))[, c("p.value", "ci.lower", "ci.upper")]),
     matrix(NA, nrow = 1, ncol = 3)
   )
 

--- a/tests/testthat/test-horvitz-thompson.R
+++ b/tests/testthat/test-horvitz-thompson.R
@@ -71,8 +71,8 @@ test_that("Horvitz-Thompson works in simple case", {
   )
 
   expect_equal(
-    tidy(ht_simp)[, c("coefficients", "se")],
-    tidy(ht_rev)[, c("coefficients", "se")] * c(-1, 1)
+    tidy(ht_simp)[, c("estimate", "std.error")],
+    tidy(ht_rev)[, c("estimate", "std.error")] * c(-1, 1)
   )
 
   # Simple designs needn't use condition matrix as joint prs are product of marginals
@@ -474,8 +474,8 @@ test_that("Works without variation in treatment", {
 
   # This is only true because condition prs are 0.5
   expect_identical(
-    tidy(ht_zero)[c("coefficients", "se")],
-    tidy(ht_rev)[c("coefficients", "se")] * c(-1, 1)
+    tidy(ht_zero)[c("estimate", "std.error")],
+    tidy(ht_rev)[c("estimate", "std.error")] * c(-1, 1)
   )
 
   # Some weird specifications that hit unusual parts of the variance

--- a/tests/testthat/test-iv-robust.R
+++ b/tests/testthat/test-iv-robust.R
@@ -37,7 +37,7 @@ test_that("iv_robust matches AER + ivpack", {
   ivo <- summary(ivfit)
 
   expect_equivalent(
-    as.matrix(tidy(ivco)[, c("coefficients", "se", "p")]),
+    as.matrix(tidy(ivco)[, c("estimate", "std.error", "p.value")]),
     ivo$coefficients[, c(1, 2, 4)]
   )
   # Same as stata if you specify `small` as a stata option
@@ -48,7 +48,7 @@ test_that("iv_robust matches AER + ivpack", {
   ivpackrob <- robust.se(ivfit)
 
   expect_equivalent(
-    as.matrix(tidy(ivro)[, c("coefficients", "se", "p")]),
+    as.matrix(tidy(ivro)[, c("estimate", "std.error", "p.value")]),
     ivpackrob[, c(1, 2, 4)]
   )
 
@@ -59,7 +59,7 @@ test_that("iv_robust matches AER + ivpack", {
   # Our p-values are bigger (ivpack is be using less conservative DF, we use J - 1 which
   # is what stata uses for clusters w/ `small` and in OLS)
   expect_equivalent(
-    as.matrix(tidy(ivclusto)[, c("coefficients", "se")]),
+    as.matrix(tidy(ivclusto)[, c("estimate", "std.error")]),
     ivpackclust[, c(1, 2)]
   )
 
@@ -68,7 +68,7 @@ test_that("iv_robust matches AER + ivpack", {
   clubsando <- clubSandwich::coef_test(ivfit, vcov = "CR2", cluster = dat$clust)
 
   expect_equivalent(
-    as.matrix(tidy(ivcr2o)[, c("coefficients", "se", "df", "p")]),
+    as.matrix(tidy(ivcr2o)[, c("estimate", "std.error", "df", "p.value")]),
     as.matrix(clubsando)
   )
   # CR0
@@ -76,7 +76,7 @@ test_that("iv_robust matches AER + ivpack", {
   clubsandCR0o <- clubSandwich::coef_test(ivfit, vcov = "CR0", cluster = dat$clust, test = "naive-t")
 
   expect_equivalent(
-    as.matrix(tidy(ivcr0o)[, c("coefficients", "se", "p")]),
+    as.matrix(tidy(ivcr0o)[, c("estimate", "std.error", "p.value")]),
     as.matrix(clubsandCR0o)
   )
 
@@ -86,7 +86,7 @@ test_that("iv_robust matches AER + ivpack", {
   ivregsum <- summary(ivw)
 
   expect_equivalent(
-    as.matrix(tidy(ivcw)[, c("coefficients", "se", "p")]),
+    as.matrix(tidy(ivcw)[, c("estimate", "std.error", "p.value")]),
     ivregsum$coefficients[, c(1, 2, 4)]
   )
 
@@ -95,7 +95,7 @@ test_that("iv_robust matches AER + ivpack", {
   ivpackrobw <- robust.se(ivw)
 
   expect_equivalent(
-    as.matrix(tidy(ivrw)[, c("coefficients", "se", "p")]),
+    as.matrix(tidy(ivrw)[, c("estimate", "std.error", "p.value")]),
     ivpackrobw[, c(1, 2, 4)]
   )
 
@@ -104,7 +104,7 @@ test_that("iv_robust matches AER + ivpack", {
   clubsandwo <- clubSandwich::coef_test(ivw, vcov = "CR2", cluster = dat$clust)
 
   expect_equivalent(
-    as.matrix(tidy(ivcr2wo)[, c("coefficients", "se", "df", "p")]),
+    as.matrix(tidy(ivcr2wo)[, c("estimate", "std.error", "df", "p.value")]),
     as.matrix(clubsandwo)
   )
 
@@ -113,7 +113,7 @@ test_that("iv_robust matches AER + ivpack", {
   clubsandCR0wo <- clubSandwich::coef_test(ivw, vcov = "CR0", cluster = dat$clust, test = "naive-t")
 
   expect_equivalent(
-    as.matrix(tidy(ivcr0wo)[, c("coefficients", "se", "p")]),
+    as.matrix(tidy(ivcr0wo)[, c("estimate", "std.error", "p.value")]),
     as.matrix(clubsandCR0wo)
   )
 
@@ -130,7 +130,7 @@ test_that("iv_robust matches AER + ivpack", {
   )
 
   expect_equivalent(
-    as.matrix(tidy(ivdefr)[1:2, c("coefficients", "se", "p")]),
+    as.matrix(tidy(ivdefr)[1:2, c("estimate", "std.error", "p.value")]),
     ivdefse[, c(1, 2, 4)]
   )
 
@@ -145,7 +145,7 @@ test_that("iv_robust matches AER + ivpack", {
   )
 
   expect_equivalent(
-    as.matrix(tidy(ivdefri)[1:2, c("coefficients", "se", "p")]),
+    as.matrix(tidy(ivdefri)[1:2, c("estimate", "std.error", "p.value")]),
     ivdefsei[, c(1, 2, 4)]
   )
 
@@ -160,7 +160,7 @@ test_that("iv_robust matches AER + ivpack", {
   )
 
   expect_equivalent(
-    as.matrix(tidy(ivdefclr)[1:2, c("coefficients", "se")]),
+    as.matrix(tidy(ivdefclr)[1:2, c("estimate", "std.error")]),
     ivdefclse[, c(1, 2)]
   )
 
@@ -171,7 +171,7 @@ test_that("iv_robust matches AER + ivpack", {
 
 
   expect_equivalent(
-    as.matrix(tidy(ivdefcl2r)[1:2, c("coefficients", "se", "df", "p")]),
+    as.matrix(tidy(ivdefcl2r)[1:2, c("estimate", "std.error", "df", "p.value")]),
     as.matrix(ivdefcl2se)
   )
 
@@ -186,7 +186,7 @@ test_that("iv_robust matches AER + ivpack", {
   )
 
   expect_equivalent(
-    as.matrix(tidy(ivdefrw)[1:2, c("coefficients", "se", "p")]),
+    as.matrix(tidy(ivdefrw)[1:2, c("estimate", "std.error", "p.value")]),
     ivdefsew[, c(1, 2, 4)]
   )
 
@@ -196,7 +196,7 @@ test_that("iv_robust matches AER + ivpack", {
   ivdefclsew <- clubSandwich::coef_test(ivdefclw, vcov = "CR2", cluster = dat$clust)
 
   expect_equivalent(
-    as.matrix(tidy(ivdefclrw)[1:2, c("coefficients", "se", "p")]),
+    as.matrix(tidy(ivdefclrw)[1:2, c("estimate", "std.error", "p.value")]),
     as.matrix(ivdefclsew)[, c(1, 2, 4)]
   )
 
@@ -206,7 +206,7 @@ test_that("iv_robust matches AER + ivpack", {
   ivdef2clsew <- clubSandwich::coef_test(ivdef2clw, vcov = "CR2", cluster = dat$clust)
 
   expect_equivalent(
-    as.matrix(tidy(ivdef2clrw)[1:2, c("coefficients", "se", "p")]),
+    as.matrix(tidy(ivdef2clrw)[1:2, c("estimate", "std.error", "p.value")]),
     as.matrix(ivdef2clsew)[, c(1, 2, 4)]
   )
 })
@@ -222,7 +222,7 @@ test_that("iv_robust different specifications work", {
   ivo <- ivreg(mpg ~ wt | hp + cyl, data = mtcars)
   ivpo <- robust.se(ivo)
   expect_equivalent(
-    as.matrix(tidy(ivro)[, c("coefficients", "se", "p")]),
+    as.matrix(tidy(ivro)[, c("estimate", "std.error", "p.value")]),
     ivpo[, c(1, 2, 4)]
   )
 
@@ -231,7 +231,7 @@ test_that("iv_robust different specifications work", {
   # ivo <- ivreg(mpg ~ wt + hp + vs | . - vs + cyl, data = mtcars)
   # ivpo <- robust.se(ivo)
   # expect_equivalent(
-  #   as.matrix(tidy(ivro)[, c("coefficients", "se", "p")]),
+  #   as.matrix(tidy(ivro)[, c("estimate", "std.error", "p.value")]),
   #   ivpo[, c(1, 2, 4)]
   # )
 
@@ -240,7 +240,7 @@ test_that("iv_robust different specifications work", {
   ivo <- ivreg(mpg ~ . | ., data = mtcars)
   ivpo <- robust.se(ivo)
   expect_equivalent(
-    as.matrix(tidy(ivro)[, c("coefficients", "se", "p")]),
+    as.matrix(tidy(ivro)[, c("estimate", "std.error", "p.value")]),
     ivpo[, c(1, 2, 4)]
   )
 

--- a/tests/testthat/test-lm-cluster.R
+++ b/tests/testthat/test-lm-cluster.R
@@ -40,7 +40,7 @@ test_that("lm cluster se", {
           ci = FALSE,
           data = dat
         )
-      )[, c("p", "ci_lower", "ci_upper")]
+      )[, c("p.value", "ci.lower", "ci.upper")]
     ),
     matrix(NA, nrow = 3, ncol = 3)
   )
@@ -81,12 +81,12 @@ test_that("lm cluster se", {
     qt(0.975, df = length(unique(dat$J)) - 1) * bm_interact$se.Stata["Z:X"] * c(-1, 1)
 
   expect_equivalent(
-    tidy(lm_interact)[4, c("std.error", "ci_lower", "ci_upper")],
+    tidy(lm_interact)[4, c("std.error", "ci.lower", "ci.upper")],
     c(bm_interact$se["Z:X"], bm_interact_interval)
   )
 
   expect_equivalent(
-    tidy(lm_interact_stata)[4, c("std.error", "ci_lower", "ci_upper")],
+    tidy(lm_interact_stata)[4, c("std.error", "ci.lower", "ci.upper")],
     c(bm_interact$se.Stata["Z:X"], bm_interact_stata_interval)
   )
 
@@ -112,7 +112,7 @@ test_that("lm cluster se", {
   bm_full_upper <- lm_full_simple$coefficients + bm_full_moe
 
   expect_equivalent(
-    as.matrix(tidy(lm_full)[, c("std.error", "ci_lower", "ci_upper")]),
+    as.matrix(tidy(lm_full)[, c("std.error", "ci.lower", "ci.upper")]),
     cbind(bm_full$se, bm_full_lower, bm_full_upper)
   )
 
@@ -311,12 +311,12 @@ test_that("Clustered SEs work with clusters of size 1", {
     )
 
   expect_equivalent(
-    as.matrix(tidy(lm_cr2)[, c("coefficients", "std.error", "df")]),
+    as.matrix(tidy(lm_cr2)[, c("estimate", "std.error", "df")]),
     cbind(lmo$coefficients, bmo$se, bmo$dof)
   )
 
   expect_equivalent(
-    as.matrix(tidy(lm_stata)[, c("coefficients", "std.error")]),
+    as.matrix(tidy(lm_stata)[, c("estimate", "std.error")]),
     cbind(lmo$coefficients, bmo$se.Stata)
   )
 })

--- a/tests/testthat/test-lm-cluster.R
+++ b/tests/testthat/test-lm-cluster.R
@@ -81,12 +81,12 @@ test_that("lm cluster se", {
     qt(0.975, df = length(unique(dat$J)) - 1) * bm_interact$se.Stata["Z:X"] * c(-1, 1)
 
   expect_equivalent(
-    tidy(lm_interact)[4, c("se", "ci_lower", "ci_upper")],
+    tidy(lm_interact)[4, c("std.error", "ci_lower", "ci_upper")],
     c(bm_interact$se["Z:X"], bm_interact_interval)
   )
 
   expect_equivalent(
-    tidy(lm_interact_stata)[4, c("se", "ci_lower", "ci_upper")],
+    tidy(lm_interact_stata)[4, c("std.error", "ci_lower", "ci_upper")],
     c(bm_interact$se.Stata["Z:X"], bm_interact_stata_interval)
   )
 
@@ -112,7 +112,7 @@ test_that("lm cluster se", {
   bm_full_upper <- lm_full_simple$coefficients + bm_full_moe
 
   expect_equivalent(
-    as.matrix(tidy(lm_full)[, c("se", "ci_lower", "ci_upper")]),
+    as.matrix(tidy(lm_full)[, c("std.error", "ci_lower", "ci_upper")]),
     cbind(bm_full$se, bm_full_lower, bm_full_upper)
   )
 
@@ -311,12 +311,12 @@ test_that("Clustered SEs work with clusters of size 1", {
     )
 
   expect_equivalent(
-    as.matrix(tidy(lm_cr2)[, c("coefficients", "se", "df")]),
+    as.matrix(tidy(lm_cr2)[, c("coefficients", "std.error", "df")]),
     cbind(lmo$coefficients, bmo$se, bmo$dof)
   )
 
   expect_equivalent(
-    as.matrix(tidy(lm_stata)[, c("coefficients", "se")]),
+    as.matrix(tidy(lm_stata)[, c("coefficients", "std.error")]),
     cbind(lmo$coefficients, bmo$se.Stata)
   )
 })

--- a/tests/testthat/test-lm-robust.R
+++ b/tests/testthat/test-lm-robust.R
@@ -137,7 +137,7 @@ test_that("lm robust works with missingness", {
   )
 
   expect_equivalent(
-    as.matrix(tidy(estimatr_missout_out)[, c("coefficients", "se")]),
+    as.matrix(tidy(estimatr_missout_out)[, c("estimate", "std.error")]),
     lm_missout_hc2
   )
 
@@ -190,7 +190,7 @@ test_that("lm robust works with weights", {
   )
 
   expect_equivalent(
-    as.matrix(tidy(estimatr_out)[, c("coefficients", "se")]),
+    as.matrix(tidy(estimatr_out)[, c("estimate", "std.error")]),
     lmo_hc2
   )
 
@@ -215,7 +215,7 @@ test_that("lm robust works with weights", {
   )
 
   expect_equivalent(
-    as.matrix(tidy(estimatr_miss_out)[, c("coefficients", "se")]),
+    as.matrix(tidy(estimatr_miss_out)[, c("estimate", "std.error")]),
     lmo_miss_hc2
   )
 
@@ -288,7 +288,7 @@ test_that("lm robust works with rank-deficient X", {
 
   ## order sometimes is different! Not stable order!
   # expect_equivalent(
-  #   as.matrix(tidy(lm_robust(Y ~ X1 + X2 + Z1 + X3, data = dat, se_type = 'classical'))[, c('coefficients', 'se')]),
+  #   as.matrix(tidy(lm_robust(Y ~ X1 + X2 + Z1 + X3, data = dat, se_type = 'classical'))[, c('estimate', 'std.error')]),
   #   out_sumlm
   # )
 
@@ -298,7 +298,7 @@ test_that("lm robust works with rank-deficient X", {
 
   ## Not the same as LM! Different QR decompositions when dependency isn't just equivalency
   expect_equivalent(
-    as.matrix(tidy(lm_robust(Y ~ X1 + X2 + Z1 + X3, data = dat, se_type = "classical"))[, c("coefficients", "se")]),
+    as.matrix(tidy(lm_robust(Y ~ X1 + X2 + Z1 + X3, data = dat, se_type = "classical"))[, c("estimate", "std.error")]),
     as.matrix(summary(RcppEigen::fastLm(Y ~ X1 + X2 + Z1 + X3, data = dat))$coefficients[, 1:2])
   )
 
@@ -372,7 +372,7 @@ test_that("multiple outcomes", {
   mo <- tidy(lmro)
 
   expect_identical(
-    mo$coefficient_name,
+    mo$term,
     c("(Intercept)", "cyl", "(Intercept)", "cyl")
   )
 

--- a/tests/testthat/test-replicate-HT-middleton.R
+++ b/tests/testthat/test-replicate-HT-middleton.R
@@ -80,11 +80,11 @@ test_that("We match Joel's estimator", {
   )
 
   expect_equal(
-    tidy(ht_decl_o)[, c("coefficients", "se")],
-    tidy(ht_prob_o)[, c("coefficients", "se")]
+    tidy(ht_decl_o)[, c("estimate", "std.error")],
+    tidy(ht_prob_o)[, c("estimate", "std.error")]
   )
   expect_equivalent(
-    tidy(ht_decl_o)[, c("coefficients", "se")],
+    tidy(ht_decl_o)[, c("estimate", "std.error")],
     c(ht_est, se_ht)
   )
 
@@ -101,7 +101,7 @@ test_that("We match Joel's estimator", {
   )
 
   expect_equivalent(
-    tidy(ht_const_o)[, c("coefficients", "se")],
+    tidy(ht_const_o)[, c("estimate", "std.error")],
     c(ht_est, se_constant_ht)
   )
 
@@ -134,7 +134,7 @@ test_that("We match Joel's estimator", {
 
   # Don't match right now because pmats are diff
   # expect_equal(
-  #   tidy(ht_comp_decl_o)[, c("coefficients", "se")],
+  #   tidy(ht_comp_decl_o)[, c("estimate", "std.error")],
   #   c(ht_comp_est, se_comp_ht)
   # )
 
@@ -145,7 +145,7 @@ test_that("We match Joel's estimator", {
     condition_pr_mat = pmat.CR.true
   )
   expect_equivalent(
-    tidy(ht_comp_decl_o)[, c("coefficients", "se")],
+    tidy(ht_comp_decl_o)[, c("estimate", "std.error")],
     c(ht_comp_est, se_comp_ht)
   )
 
@@ -162,7 +162,7 @@ test_that("We match Joel's estimator", {
   # )
   #
   # expect_equivalent(
-  #   tidy(ht_comp_const_o)[, c("coefficients", "se")],
+  #   tidy(ht_comp_const_o)[, c("estimate", "std.error")],
   #   c(ht_comp_est, se_comp_constant_ht)
   # )
 
@@ -174,7 +174,7 @@ test_that("We match Joel's estimator", {
   #   se_type = "constant"
   # )
   # expect_equivalent(
-  #   tidy(ht_comp_const_o)[, c("coefficients", "se")],
+  #   tidy(ht_comp_const_o)[, c("estimate", "std.error")],
   #   c(ht_comp_est, se_comp_constant_ht)
   # )
 

--- a/tests/testthat/test-replicate-lin2013.R
+++ b/tests/testthat/test-replicate-lin2013.R
@@ -22,7 +22,7 @@ test_that("lm_lin recreates Lin 2013 Table 2", {
           data = alo_star_men,
           se_type = "HC0"
         )
-      )[2, c("coefficients", "se")],
+      )[2, c("estimate", "std.error")],
       3
     ),
     c(-0.036, 0.158)
@@ -38,7 +38,7 @@ test_that("lm_lin recreates Lin 2013 Table 2", {
           data = alo_star_men,
           se_type = "HC0"
         )
-      )[2, c("coefficients", "se")],
+      )[2, c("estimate", "std.error")],
       3
     )),
     c(-0.083, 0.146)
@@ -54,7 +54,7 @@ test_that("lm_lin recreates Lin 2013 Table 2", {
           data = alo_star_men,
           se_type = "HC0"
         )
-      )[2, c("coefficients", "se")],
+      )[2, c("estimate", "std.error")],
       3
     )),
     c(-0.081, 0.146)

--- a/tests/testthat/test-s3-methods.R
+++ b/tests/testthat/test-s3-methods.R
@@ -52,7 +52,7 @@ test_that("tidy, summary, and print work", {
   slmmo <- summary(lmmo)
 
   expect_equivalent(
-    as.matrix(tidy(lmrmo)[, c("coefficient_name", "outcome")]),
+    as.matrix(tidy(lmrmo)[, c("term", "outcome")]),
     cbind(
       rep(c("(Intercept)", "z"), times = 2),
       rep(c("y", "x"), each = 2)
@@ -145,7 +145,7 @@ test_that("tidy, summary, and print work", {
   )
 
   expect_equivalent(
-    as.matrix(tidy(ht)[, c("coefficients", "se", "p", "ci_lower", "ci_upper", "df")]),
+    as.matrix(tidy(ht)[, c("estimate", "std.error", "p.value", "ci.lower", "ci.upper", "df")]),
     summary(ht)$coefficients
   )
 


### PR DESCRIPTION
Really weird that the list output doesn't match the tidy output now, but I think matching the tidy output is probably right so that everything is internally consistent.. There are 3 problems with also changing the list output of the estimator functions:

1. `lm` returns an object with `res$coefficients` and if we change our list so that the coefficients are in `robres$estimate`, but `summary(robres)$coefficients` still matches `summary(res)$coefficients`, then we are sometimes matching, sometimes not.
2. We have a (small) set of users who might be thrown off by this (I don't think this is a real big concern as now is the time to make this change if ever).
3. We have to rework DD diagnosands and designs to also be consistent, because otherwise it's still internally inconsistent

I think @nfultz is in favor of aligning everything, doing the work across DD and estimatr, and just not worrying about matching `lm` output.

I agree with him.

I need input from the bosses so that we can fix this today and go for CRAN with something we are committed to for the long run.