### PR TITLE
Change how ht parses data

### DIFF
--- a/R/estimatr_difference_in_means.R
+++ b/R/estimatr_difference_in_means.R
@@ -230,7 +230,7 @@ difference_in_means <-
       cluster = clusters
     )
     data <- enquo(data)
-    model_data <- clean_model_data(data = data, datargs)
+    model_data <- clean_model_data(data = data, datargs, estimator = "dim")
 
     data <- data.frame(
       y = model_data$outcome,

--- a/R/estimatr_horvitz_thompson.R
+++ b/R/estimatr_horvitz_thompson.R
@@ -241,7 +241,7 @@ horvitz_thompson <-
     # -----
     # Check arguments
     # -----
-    if (length(all.vars(formula[[3]])) > 1) {
+    if (length(all.vars(f_rhs(formula))) > 1) {
       stop(
         "'formula' must have only one variable on the right-hand side: the ",
         "treatment variable"
@@ -272,43 +272,17 @@ horvitz_thompson <-
         )
       }
 
-      # Declaration can only be used if it is the same length as the data being passed
-      if (nrow(declaration$probabilities_matrix) != nrow(data)) {
-        stop(
-          "Cannot use `declaration` if the number of observations in the ",
-          "`declaration` 'N' is different than the rows in data"
-        )
-      }
-
       # Add clusters, blocks, and treatment probabilities to data so they can be cleaned with clean_model_data
       if (!is.null(declaration$clusters)) {
-        if (!is.null(data[[".clusters_ddinternal"]])) {
-          stop(
-            "Can't have a variable called '.clusters_ddinternal' in your `data`",
-            "as we use that name for clusters from `declaration` objects."
-          )
-        }
         .clusters_ddinternal <- declaration$clusters
         clusters <- quo(.clusters_ddinternal)
       }
 
       if (!is.null(declaration$blocks)) {
-        if (!is.null(data[[".blocks_ddinternal"]])) {
-          stop(
-            "Can't have a variable called '.blocks_ddinternal' in your `data`",
-            "as we use that name for blocks from `declaration` objects."
-          )
-        }
         .blocks_ddinternal <- declaration$blocks
         blocks <- quo(.blocks_ddinternal)
       }
 
-      if (!is.null(data[[".treatment_prob_ddinternal"]])) {
-        stop(
-          "Can't have a variable called '.treatment_prob_ddinternal' in your `data`",
-          "as we use that name for treatment probabilites."
-        )
-      }
       if (!is.null(condition2)) {
         treatnum <-
           which(declaration$cleaned_arguments$condition_names == condition2)
@@ -343,7 +317,7 @@ horvitz_thompson <-
       condition_pr = condition_prs
     )
     data <- enquo(data)
-    model_data <- clean_model_data(data = data, datargs)
+    model_data <- clean_model_data(data = data, datargs, estimator = "ht")
 
     ## condition_pr_mat, if supplied, must be same length
     if (!is.null(condition_pr_mat) && (2 * length(model_data$outcome) != nrow(condition_pr_mat))) {
@@ -427,7 +401,7 @@ horvitz_thompson <-
           if (is.null(data$condition_probabilities)) {
             pr_treat <- mean(data$t == condition2)
             message(
-              "Learning probability of complete random assignment from data with",
+              "Learning probability of complete random assignment from data with ",
               "prob = ", round(pr_treat, 3)
             )
             condition_pr_mat <- gen_pr_matrix_complete(

--- a/R/estimatr_iv_robust.R
+++ b/R/estimatr_iv_robust.R
@@ -124,7 +124,7 @@ iv_robust <- function(formula,
     cluster = clusters
   )
   data <- enquo(data)
-  model_data <- clean_model_data(data = data, datargs, instruments = TRUE)
+  model_data <- clean_model_data(data = data, datargs, estimator = "iv")
 
   if (ncol(model_data$instrument_matrix) < ncol(model_data$design_matrix))  {
     warning("More regressors than instruments")


### PR DESCRIPTION
This does two things:

1. Changes `clean_model_data` to take a string for which estimator is calling it so that we can do better handling some things that need to be added to the data. Could break these into separate fns, but I'm not sure that's better.
2. Allows ht to work with a declaration and without data. Before it tried to check things in the declaration against things in the data but the data might not exist and so it was erroring. Now, there is v little chance of internal clash over naming since fultzy prepends `.__251353...` to auxiliary variables. Also, different lengths of variables in the `declaration` and `data` if it is passed is just handled by `model.frame`