### PR TITLE
tests

### DIFF
--- a/tests/testthat/test-iv-robust.R
+++ b/tests/testthat/test-iv-robust.R
@@ -172,7 +172,7 @@ test_that("iv_robust matches AER + ivpack", {
 
   expect_equivalent(
     as.matrix(tidy(ivdefcl2r)[1:2, c("estimate", "std.error", "df", "p.value")]),
-    as.matrix(ivdefcl2se)
+    as.matrix(ivdefcl2se[-3,])
   )
 
   # HC0 Weighted
@@ -197,7 +197,7 @@ test_that("iv_robust matches AER + ivpack", {
 
   expect_equivalent(
     as.matrix(tidy(ivdefclrw)[1:2, c("estimate", "std.error", "p.value")]),
-    as.matrix(ivdefclsew)[, c(1, 2, 4)]
+    as.matrix(ivdefclsew)[-3, c(1, 2, 4)]
   )
 
 
@@ -207,7 +207,7 @@ test_that("iv_robust matches AER + ivpack", {
 
   expect_equivalent(
     as.matrix(tidy(ivdef2clrw)[1:2, c("estimate", "std.error", "p.value")]),
-    as.matrix(ivdef2clsew)[, c(1, 2, 4)]
+    as.matrix(ivdef2clsew)[-3, c(1, 2, 4)]
   )
 })
 


### PR DESCRIPTION
Fixes the following types of errors

```r
> as.matrix(ivdefclsew)[, c(1, 2, 4)]
                      beta           SE       p_Satt
(Intercept) -0.03448738093 0.3084088213 0.9226543092
x           -0.25747207720 0.3065834519 0.5240432855
x1_c                    NA           NA           NA
> as.matrix(tidy(ivdefclrw)[1:2, c("estimate", "std.error", "p.value")])
1 coefficient not defined because the design matrix is rank deficient

        estimate    std.error      p.value
1 -0.03448738093 0.3084088213 0.9226543092
2 -0.25747207720 0.3065834519 0.5240432855
```