### PR TITLE
rmcall failures

### DIFF
--- a/tests/testthat/helper-rm-call.R
+++ b/tests/testthat/helper-rm-call.R
@@ -1,7 +1,0 @@
-# This file removes calls from function returns to make testing easier
-rmcall <- function(obj) {
-  if (!is.null(obj[["call"]])) {
-    obj[["call"]] <- NULL
-  }
-  return(obj)
-}

--- a/tests/testthat/test-lm-robust.R
+++ b/tests/testthat/test-lm-robust.R
@@ -1,5 +1,12 @@
 context("Estimator - lm_robust, non-clustered")
 
+# This file removes calls from function returns to make testing easier
+rmcall <- function(obj) {
+  obj[["call"]] <- NULL
+  obj
+}
+
+
 test_that("lm robust se", {
   set.seed(42)
   N <- 40


### PR DESCRIPTION
Fixes tests failing like


test-lm-cluster.R:286: error: lm works with quoted or unquoted vars and withor without factor clusters
could not find function "rmcall"
1: expect_equivalent(rmcall(lm_robust(Y ~ Z, data = dat, clusters = J_fac)), rmcall(lm_robust(Y ~ Z, data = dat, 
       clusters = J))) at /home/nfultz/projects/DD/estimatr/tests/testthat/test-lm-cluster.R:286
2: quasi_label(enquo(object), label)
3: eval_bare(get_expr(quo), get_env(quo))
