### PR TITLE
Update vcov for 3.5

### DIFF
--- a/R/S3_vcov.R
+++ b/R/S3_vcov.R
@@ -1,38 +1,45 @@
 #' @export
 vcov.lm_robust <-
-  function(object, ...) {
-    return(vcov_simple(object))
+  function(object, complete = TRUE, ...) {
+    return(vcov_simple(object, complete = complete))
   }
 
 #' @export
 vcov.iv_robust <-
-  function(object, ...) {
-    return(vcov_simple(object))
+  function(object, complete = TRUE, ...) {
+    return(vcov_simple(object, complete = complete))
   }
 
 #' @export
 vcov.difference_in_means <-
-  function(object, ...) {
+  function(object, complete = TRUE, ...) {
     stop("vcov not supported for difference_in_means")
   }
 
 
 #' @export
 vcov.horvitz_thompson <-
-  function(object, ...) {
+  function(object, complete = TRUE, ...) {
     stop("vcov not supported for horvitz_thompson")
   }
 
 
 # Helper function for extracting vcov when it is just an element in the object list
 vcov_simple <-
-  function(object) {
+  function(object, complete) {
     if (is.null(object$vcov)) {
       stop(
         "Object must have vcov matrix. Try setting `return_vcov = TRUE` in ",
         "the estimator function."
       )
     } else {
-      return(object$vcov)
+      if (complete && (object$rank < object$k)) {
+        vc <- matrix(NA_real_, object$k, object$k, dimnames = list(object$term, object$term))
+        j <- which(!is.na(coef(object, complete = TRUE)))
+        vc[j, j] <- object$vcov
+        return(vc)
+      } else {
+        return(object$vcov)
+      }
     }
   }

--- a/tests/testthat/test-s3-methods.R
+++ b/tests/testthat/test-s3-methods.R
@@ -226,7 +226,17 @@ test_that("vcov works", {
   dat$xdup <- dat$x
   expect_equal(
     vcov(lm_robust(y ~ x + xdup, data = dat, se_type = "classical")),
-    vcov(lm(y ~ x + xdub, data = dat))
+    vcov(lm(y ~ x + xdup, data = dat))
+  )
+
+  expect_equal(
+    coef(lm_robust(y ~ x + xdup, data = dat, se_type = "classical")),
+    coef(lm(y ~ x + xdup, data = dat))
+  )
+
+  expect_equal(
+    coef(lm_robust(y ~ x + xdup, data = dat, se_type = "classical"), complete = FALSE),
+    coef(lm(y ~ x + xdup, data = dat), complete = FALSE)
   )
 
   expect_equal(

--- a/tests/testthat/test-s3-methods.R
+++ b/tests/testthat/test-s3-methods.R
@@ -222,6 +222,13 @@ test_that("vcov works", {
     vcov(lm(y ~ x, data = dat))
   )
 
+  # support complete with dependencies
+  dat$xdup <- dat$x
+  expect_equal(
+    vcov(lm_robust(y ~ x + xdup, data = dat, se_type = "classical")),
+    vcov(lm(y ~ x + xdub, data = dat))
+  )
+
   expect_equal(
     vcov(lmbo)["z", "z"],
     vcov(lmfo)["z", "z"]


### PR DESCRIPTION
Also adds test for new coef (code looks fine to continue relying on `coef.default`.

Closes #204. Can't see any other pertinent S3 changes.