### PR TITLE
estimatr::tidy colnames are compatible with broom:tidy colnames

### DIFF
--- a/R/S3_confint.R
+++ b/R/S3_confint.R
@@ -51,13 +51,13 @@ get_ci_mat <- function(object, level, ttest = TRUE) {
   }
 
   cis <- cbind(
-    as.vector(object$ci.lower),
-    as.vector(object$ci.upper)
+    as.vector(object$conf.low),
+    as.vector(object$conf.high)
   )
 
-  if (is.matrix(object$ci.lower)) {
-    ny <- ncol(object$ci.lower)
-    p <- nrow(object$ci.lower)
+  if (is.matrix(object$conf.low)) {
+    ny <- ncol(object$conf.low)
+    p <- nrow(object$conf.low)
     rownames(cis) <- paste0(
       rep(object$outcome, each = p),
       ":",

--- a/R/S3_summary.R
+++ b/R/S3_summary.R
@@ -12,8 +12,8 @@ summary.lm_robust <- function(object, ...) {
       "coefficients",
       "std.error",
       "df",
-      "ci.lower",
-      "ci.upper",
+      "conf.low",
+      "conf.high",
       "p.value"
     )
 
@@ -105,12 +105,12 @@ summarize_tidy <- function(object, test = "t", ...) {
   tidy_out <- tidy(object, ...)
   colnames(tidy_out)[2:7] <-
     c(
-      "Estimate",
-      "Std. Error",
-      paste0("Pr(>|", test, "|)"),
-      "CI Lower",
-      "CI Upper",
-      "DF"
+      "estimate",
+      "std.error",
+      paste0(test, ".value"),
+      "conf.low",
+      "conf.high",
+      "df"
     )
   tidy_mat <- as.matrix(tidy_out[, !(names(tidy_out) %in% remove_cols)])
 

--- a/R/S3_tidy.R
+++ b/R/S3_tidy.R
@@ -91,8 +91,8 @@ tidy_data_frame <- function(object, digits = NULL) {
       "coefficients",
       "std.error",
       "p.value",
-      "ci.lower",
-      "ci.upper",
+      "conf.low",
+      "conf.high",
       "df"
     )
 

--- a/R/estimatr_difference_in_means.R
+++ b/R/estimatr_difference_in_means.R
@@ -69,8 +69,8 @@
 #'   \item{std.error}{the estimated standard error}
 #'   \item{df}{the estimated degrees of freedom}
 #'   \item{p.value}{the p-value from a two-sided t-test using \code{coefficients}, \code{std.error}, and \code{df}}
-#'   \item{ci.lower}{the lower bound of the \code{1 - alpha} percent confidence interval}
-#'   \item{ci.upper}{the upper bound of the \code{1 - alpha} percent confidence interval}
+#'   \item{conf.low}{the lower bound of the \code{1 - alpha} percent confidence interval}
+#'   \item{conf.high}{the upper bound of the \code{1 - alpha} percent confidence interval}
 #'   \item{term}{a character vector of coefficient names}
 #'   \item{alpha}{the significance level specified by the user}
 #'   \item{N}{the number of observations used}

--- a/R/estimatr_horvitz_thompson.R
+++ b/R/estimatr_horvitz_thompson.R
@@ -125,8 +125,8 @@
 #'   \item{std.error}{the estimated standard error}
 #'   \item{df}{the estimated degrees of freedom}
 #'   \item{p.value}{the p-value from a two-sided z-test using \code{coefficients} and \code{std.error}}
-#'   \item{ci.lower}{the lower bound of the \code{1 - alpha} percent confidence interval}
-#'   \item{ci.upper}{the upper bound of the \code{1 - alpha} percent confidence interval}
+#'   \item{conf.low}{the lower bound of the \code{1 - alpha} percent confidence interval}
+#'   \item{conf.high}{the upper bound of the \code{1 - alpha} percent confidence interval}
 #'   \item{term}{a character vector of coefficient names}
 #'   \item{alpha}{the significance level specified by the user}
 #'   \item{N}{the number of observations used}

--- a/R/estimatr_iv_robust.R
+++ b/R/estimatr_iv_robust.R
@@ -79,8 +79,8 @@
 #'   \item{std.error}{the estimated standard errors}
 #'   \item{df}{the estimated degrees of freedom}
 #'   \item{p.value}{the p-values from a two-sided t-test using \code{coefficients}, \code{std.error}, and \code{df}}
-#'   \item{ci.lower}{the lower bound of the \code{1 - alpha} percent confidence interval}
-#'   \item{ci.upper}{the upper bound of the \code{1 - alpha} percent confidence interval}
+#'   \item{conf.low}{the lower bound of the \code{1 - alpha} percent confidence interval}
+#'   \item{conf.high}{the upper bound of the \code{1 - alpha} percent confidence interval}
 #'   \item{term}{a character vector of coefficient names}
 #'   \item{alpha}{the significance level specified by the user}
 #'   \item{se_type}{the standard error type specified by the user}

--- a/R/estimatr_lm_lin.R
+++ b/R/estimatr_lm_lin.R
@@ -64,8 +64,8 @@
 #'   \item{std.error}{the estimated standard errors}
 #'   \item{df}{the estimated degrees of freedom}
 #'   \item{p.value}{the p-values from a two-sided t-test using \code{coefficients}, \code{std.error}, and \code{df}}
-#'   \item{ci.lower}{the lower bound of the \code{1 - alpha} percent confidence interval}
-#'   \item{ci.upper}{the upper bound of the \code{1 - alpha} percent confidence interval}
+#'   \item{conf.low}{the lower bound of the \code{1 - alpha} percent confidence interval}
+#'   \item{conf.high}{the upper bound of the \code{1 - alpha} percent confidence interval}
 #'   \item{term}{a character vector of coefficient names}
 #'   \item{alpha}{the significance level specified by the user}
 #'   \item{se_type}{the standard error type specified by the user}

--- a/R/estimatr_lm_robust.R
+++ b/R/estimatr_lm_robust.R
@@ -92,8 +92,8 @@
 #'   \item{std.error}{the estimated standard errors}
 #'   \item{df}{the estimated degrees of freedom}
 #'   \item{p.value}{the p-values from a two-sided t-test using \code{coefficients}, \code{std.error}, and \code{df}}
-#'   \item{ci.lower}{the lower bound of the \code{1 - alpha} percent confidence interval}
-#'   \item{ci.upper}{the upper bound of the \code{1 - alpha} percent confidence interval}
+#'   \item{conf.low}{the lower bound of the \code{1 - alpha} percent confidence interval}
+#'   \item{conf.high}{the upper bound of the \code{1 - alpha} percent confidence interval}
 #'   \item{term}{a character vector of coefficient names}
 #'   \item{alpha}{the significance level specified by the user}
 #'   \item{se_type}{the standard error type specified by the user}
@@ -149,7 +149,7 @@
 #' coef(lmro)
 #' tidy(lmro)$estimate
 #' # Can also get confidence intervals from object or with new 1 - `alpha`
-#' lmro$ci.lower
+#' lmro$conf.low
 #' confint(lmro, level = 0.8)
 #'
 #' # Can recover classical standard errors

--- a/R/helper_cis_pvals.R
+++ b/R/helper_cis_pvals.R
@@ -32,14 +32,14 @@ add_cis_pvals <- function(return_frame, alpha, ci, ttest = TRUE) {
       return_frame$df <- NA
     }
 
-    return_frame$ci.lower <- with(return_frame, coefficients - crit_se)
-    return_frame$ci.upper <- with(return_frame, coefficients + crit_se)
+    return_frame$conf.low <- with(return_frame, coefficients - crit_se)
+    return_frame$conf.high <- with(return_frame, coefficients + crit_se)
 
     return(as.list(return_frame))
   } else {
     return_frame$p.value <- NA
-    return_frame$ci.lower <- NA
-    return_frame$ci.upper <- NA
+    return_frame$conf.low<- NA
+    return_frame$conf.high <- NA
 
     return(as.list(return_frame))
   }

--- a/R/helper_return.R
+++ b/R/helper_return.R
@@ -20,7 +20,7 @@ lm_return <- function(return_list, model_data, formula) {
     dimnames(return_list[["std.error"]]) <- dimnames(return_list[["coefficients"]])
   } else {
     return_list[["coefficients"]] <- drop(return_list[["coefficients"]])
-    nms <- c("std.error", "p.value", "df", "ci.lower", "ci.upper")
+    nms <- c("std.error", "p.value", "df", "conf.low", "conf.high")
     for (nm in nms) {
       if (length(return_list[[nm]]) > 1 || !is.na(return_list[[nm]])) {
         return_list[[nm]] <- setNames(

--- a/R/helper_starprep.R
+++ b/R/helper_starprep.R
@@ -257,7 +257,7 @@ starprep <- function(...,
   stat <- match.arg(stat)
 
   if (stat == "ci") {
-    out <- lapply(fitlist, function(x) cbind(x[["ci.lower"]], x[["ci.upper"]]))
+    out <- lapply(fitlist, function(x) cbind(x[["conf.low"]], x[["conf.high"]]))
   } else {
     out <- lapply(fitlist, `[[`, stat)
   }

--- a/tests/testthat/test-difference-in-means.R
+++ b/tests/testthat/test-difference-in-means.R
@@ -22,7 +22,7 @@ test_that("DIM arguments parsed correctly", {
   expect_equivalent(
     as.matrix(tidy(difference_in_means(
       Y ~ Z, data = dat, ci = FALSE
-    ))[, c("p.value", "ci.lower", "ci.upper")]),
+    ))[, c("p.value", "conf.low", "conf.high")]),
     matrix(NA, nrow = 1, ncol = 3)
   )
 
@@ -99,7 +99,7 @@ test_that("DIM same as t.test", {
 
   expect_equal(
     unlist(
-      difference_in_means(Y ~ Z, data = dat)[c("p.value", "ci.lower", "ci.upper", "df")],
+      difference_in_means(Y ~ Z, data = dat)[c("p.value", "conf.low", "conf.high", "df")],
       F,
       F
     ),
@@ -147,7 +147,7 @@ test_that("DIM Clustered", {
   dim_05 <- difference_in_means(Y ~ Z, alpha = .05, clusters = J, data = dat)
   dim_10 <- difference_in_means(Y ~ Z, alpha = .10, clusters = J, data = dat)
 
-  expect_true(dim_05$ci.lower < dim_10$ci.lower)
+  expect_true(dim_05$conf.low < dim_10$conf.low)
 
   expect_equal(
     dim_10$design,
@@ -651,7 +651,7 @@ test_that("se_type = none works", {
   )
 
   expect_equivalent(
-    tidy(dim_no)[c("std.error", "p.value", "ci.lower", "ci.upper")],
+    tidy(dim_no)[c("std.error", "p.value", "conf.low", "conf.high")],
     rep(NA_real_, 4)
   )
 
@@ -665,7 +665,7 @@ test_that("se_type = none works", {
   )
 
   expect_equivalent(
-    tidy(dimb_no)[c("std.error", "p.value", "ci.lower", "ci.upper")],
+    tidy(dimb_no)[c("std.error", "p.value", "conf.low", "conf.high")],
     rep(NA_real_, 4)
   )
 
@@ -680,7 +680,7 @@ test_that("se_type = none works", {
   )
 
   expect_equivalent(
-    tidy(dimc_no)[c("std.error", "p.value", "ci.lower", "ci.upper")],
+    tidy(dimc_no)[c("std.error", "p.value", "conf.low", "conf.high")],
     rep(NA_real_, 4)
   )
 
@@ -694,7 +694,7 @@ test_that("se_type = none works", {
   )
 
   expect_equivalent(
-    tidy(dimw_no)[c("std.error", "p.value", "ci.lower", "ci.upper")],
+    tidy(dimw_no)[c("std.error", "p.value", "conf.low", "conf.high")],
     rep(NA_real_, 4)
   )
 
@@ -708,7 +708,7 @@ test_that("se_type = none works", {
   )
 
   expect_equivalent(
-    tidy(dimcw_no)[c("std.error", "p.value", "ci.lower", "ci.upper")],
+    tidy(dimcw_no)[c("std.error", "p.value", "conf.low", "conf.high")],
     rep(NA_real_, 4)
   )
 
@@ -725,7 +725,7 @@ test_that("se_type = none works", {
   )
 
   expect_equivalent(
-    tidy(dimmp_no)[c("std.error", "p.value", "ci.lower", "ci.upper")],
+    tidy(dimmp_no)[c("std.error", "p.value", "conf.low", "conf.high")],
     rep(NA_real_, 4)
   )
 })

--- a/tests/testthat/test-horvitz-thompson.R
+++ b/tests/testthat/test-horvitz-thompson.R
@@ -55,7 +55,7 @@ test_that("Horvitz-Thompson works in simple case", {
   )
 
   expect_equivalent(
-    tidy(ht_simp_no)[c("std.error", "p.value", "ci.lower", "ci.upper")],
+    tidy(ht_simp_no)[c("std.error", "p.value", "conf.low", "conf.high")],
     rep(NA_real_, 4)
   )
 
@@ -123,7 +123,7 @@ test_that("Horvitz-Thompson works in simple case", {
   )
 
   expect_equivalent(
-    tidy(ht_comp_no)[c("std.error", "p.value", "ci.lower", "ci.upper")],
+    tidy(ht_comp_no)[c("std.error", "p.value", "conf.low", "conf.high")],
     rep(NA_real_, 4)
   )
 
@@ -192,7 +192,7 @@ test_that("Horvitz-Thompson works with clustered data", {
   )
 
   expect_equivalent(
-    tidy(ht_crs_decl_no)[c("std.error", "p.value", "ci.lower", "ci.upper")],
+    tidy(ht_crs_decl_no)[c("std.error", "p.value", "conf.low", "conf.high")],
     rep(NA_real_, 4)
   )
 
@@ -229,7 +229,7 @@ test_that("Horvitz-Thompson works with clustered data", {
   )
 
   expect_equivalent(
-    tidy(ht_srs_decl_no)[c("std.error", "p.value", "ci.lower", "ci.upper")],
+    tidy(ht_srs_decl_no)[c("std.error", "p.value", "conf.low", "conf.high")],
     rep(NA_real_, 4)
   )
 
@@ -471,7 +471,7 @@ test_that("Horvitz-Thompson properly checks arguments and data", {
 
   ht_o <- horvitz_thompson(y ~ z, data = dat, ci = FALSE)
   expect_equivalent(
-    as.matrix(tidy(horvitz_thompson(y ~ z, data = dat, ci = FALSE))[, c("p.value", "ci.lower", "ci.upper")]),
+    as.matrix(tidy(horvitz_thompson(y ~ z, data = dat, ci = FALSE))[, c("p.value", "conf.low", "conf.high")]),
     matrix(NA, nrow = 1, ncol = 3)
   )
 

--- a/tests/testthat/test-lm-cluster.R
+++ b/tests/testthat/test-lm-cluster.R
@@ -40,7 +40,7 @@ test_that("lm cluster se", {
           ci = FALSE,
           data = dat
         )
-      )[, c("p.value", "ci.lower", "ci.upper")]
+      )[, c("p.value", "conf.low", "conf.high")]
     ),
     matrix(NA, nrow = 3, ncol = 3)
   )
@@ -81,12 +81,12 @@ test_that("lm cluster se", {
     qt(0.975, df = length(unique(dat$J)) - 1) * bm_interact$se.Stata["Z:X"] * c(-1, 1)
 
   expect_equivalent(
-    tidy(lm_interact)[4, c("std.error", "ci.lower", "ci.upper")],
+    tidy(lm_interact)[4, c("std.error", "conf.low", "conf.high")],
     c(bm_interact$se["Z:X"], bm_interact_interval)
   )
 
   expect_equivalent(
-    tidy(lm_interact_stata)[4, c("std.error", "ci.lower", "ci.upper")],
+    tidy(lm_interact_stata)[4, c("std.error", "conf.low", "conf.high")],
     c(bm_interact$se.Stata["Z:X"], bm_interact_stata_interval)
   )
 
@@ -112,7 +112,7 @@ test_that("lm cluster se", {
   bm_full_upper <- coef(lm_full_simple) + bm_full_moe
 
   expect_equivalent(
-    as.matrix(tidy(lm_full)[, c("std.error", "ci.lower", "ci.upper")]),
+    as.matrix(tidy(lm_full)[, c("std.error", "conf.low", "conf.high")]),
     cbind(bm_full$se, bm_full_lower, bm_full_upper)
   )
 

--- a/tests/testthat/test-replicate-lin2013.R
+++ b/tests/testthat/test-replicate-lin2013.R
@@ -72,15 +72,15 @@ if (rep_table_3) {
   its <- 250000
   set.seed(161235)
   check_cover <- function(obj, point = 0) {
-    return(obj$ci.lower[2] < point & obj$ci.upper[2] > point)
+    return(obj$conf.low[2] < point & obj$conf.high[2] > point)
   }
   ci_dist <- function(obj) {
-    return(obj$ci.upper[2] - obj$ci.lower[2])
+    return(obj$conf.high[2] - obj$conf.low[2])
   }
   ci_custom <- function(obj) {
     return(list(
-      ci.upper = coef(obj)[2] + obj$std.error[2] * 1.96,
-      ci.lower = coef(obj)[2] - obj$std.error[2] * 1.96
+      conf.high = coef(obj)[2] + obj$std.error[2] * 1.96,
+      conf.low = coef(obj)[2] - obj$std.error[2] * 1.96
     ))
   }
 

--- a/tests/testthat/test-return.R
+++ b/tests/testthat/test-return.R
@@ -17,8 +17,8 @@ test_that("Structure of output is the same", {
       "std.error",
       "df",
       "p.value",
-      "ci.lower",
-      "ci.upper",
+      "conf.low",
+      "conf.high",
       "outcome",
       "alpha",
       "N"

--- a/tests/testthat/test-s3-methods.R
+++ b/tests/testthat/test-s3-methods.R
@@ -137,7 +137,7 @@ test_that("tidy, summary, and print work", {
     summary(lmrox)
   )
 
-  expect_equal(
+  expect_equivalent(
     lapply(slmrmo, function(x) coef(x)[, c(1, 2, 3)]),
     lapply(slmmo, function(x) coef(x)[, c(1, 2, 4)])
   )
@@ -175,7 +175,7 @@ test_that("tidy, summary, and print work", {
   )
 
   expect_equivalent(
-    as.matrix(tidy(ht)[, c("estimate", "std.error", "p.value", "ci.lower", "ci.upper", "df")]),
+    as.matrix(tidy(ht)[, c("estimate", "std.error", "p.value", "conf.low", "conf.high", "df")]),
     coef(summary(ht))
   )
 
@@ -297,12 +297,12 @@ test_that("coef and confint work", {
 
   expect_equivalent(
     confint(lmo),
-    cbind(lmo$ci.lower, lmo$ci.upper)
+    cbind(lmo$conf.low, lmo$conf.high)
   )
 
   expect_equivalent(
     confint(lmfo),
-    cbind(lmfo$ci.lower, lmfo$ci.upper)
+    cbind(lmfo$conf.low, lmfo$conf.high)
   )
 
   expect_equal(
@@ -330,14 +330,14 @@ test_that("coef and confint work", {
     confint(lmo, parm = "x", level = 0.90),
     with(
       lm_robust(y ~ x, data = dat, alpha = 0.10),
-      cbind(ci.lower[2], ci.upper[2])
+      cbind(conf.low[2], conf.high[2])
     )
   )
 
   lmlo <- lm_lin(y ~ x, ~ z, data = dat, se_type = "HC3")
   expect_equivalent(
     confint(lmlo),
-    cbind(lmlo$ci.lower, lmlo$ci.upper)
+    cbind(lmlo$conf.low, lmlo$conf.high)
   )
 
   dim <- difference_in_means(y ~ x, data = dat)
@@ -347,7 +347,7 @@ test_that("coef and confint work", {
   )
   expect_equivalent(
     confint(dim),
-    cbind(dim$ci.lower, dim$ci.upper)
+    cbind(dim$conf.low, dim$conf.high)
   )
 
   ht <- horvitz_thompson(y ~ x, condition_prs = p, data = dat)
@@ -357,7 +357,7 @@ test_that("coef and confint work", {
   )
   expect_equivalent(
     confint(ht),
-    cbind(ht$ci.lower, ht$ci.upper)
+    cbind(ht$conf.low, ht$conf.high)
   )
 
   # rank deficient


### PR DESCRIPTION
I was writing software that makes strong assumptions column names in the output of `broom::tidy`. It broke when I applied it to an `lm_robust` object, because `broom::tidy` uses `ci.low` and `ci.high`, while `estimatr::tidy` uses `ci.lower` and `ci.upper`. 

Since your function seems to have been inspired by `broom`, and since that package is under the popular tidyverse umbrella, I think it makes sense to standardize column names.

This commit just substitutes the names, and fixes the tests accordingly.