### PR TITLE
Add support for one group in a fixed effect

### DIFF
--- a/R/helper_clean_model_data.R
+++ b/R/helper_clean_model_data.R
@@ -142,6 +142,11 @@ clean_model_data <- function(data, datargs, estimator = "") {
   ret[["condition_pr"]] <- model.extract(mf, "condition_pr")
 
   ret[["fixed_effects"]] <- model.extract(mf, "fixed_effects")
+  # If there is NA in the blocks and only one block, returns vector not matrix
+  # so coerce to matrix
+  if (is.character(ret[["fixed_effects"]])) {
+    ret[["fixed_effects"]] <- as.matrix(ret[["fixed_effects"]])
+  }
 
   if (any(ret[["condition_pr"]] <= 0 | ret[["condition_pr"]] > 1)) {
     stop(

--- a/R/helper_lm_robust_fit.R
+++ b/R/helper_lm_robust_fit.R
@@ -566,17 +566,19 @@ prep_data <- function(data,
 
   if (fes) {
     fe_dat <- as.data.frame(data[["fixed_effects"]])
-    fe_levels <- vapply(fe_dat, nlevels, numeric(1))
+    fe_levels <- vapply(fe_dat, nlevels, 0L)
     if (any(fe_levels == 1)) {
       if (ncol(fe_dat) == 1) {
-        data[["femat"]] <- matrix(
-          rep(1, nrow(data[["fixed_effects"]])),
-          dimnames = list(attr(data[["fixed_effects"]], "names"),
-                          paste0(colnames(data[["fixed_effects"]]), data[["fixed_effects"]][1]))
+        stop(
+          "Can't have a fixed effect with only one group AND multiple fixed ",
+          "effect variables"
         )
-      } else {
-        stop("Can't have a fixed effect with only one group AND multiple fixed effect variables")
       }
+      data[["femat"]] <- matrix(
+        rep(1, nrow(data[["fixed_effects"]])),
+        dimnames = list(attr(data[["fixed_effects"]], "names"),
+                        paste0(colnames(data[["fixed_effects"]]), data[["fixed_effects"]][1]))
+      )
     } else {
       data[["femat"]] <- model.matrix( ~ 0 + ., data = fe_dat)
     }

--- a/R/helper_lm_robust_fit.R
+++ b/R/helper_lm_robust_fit.R
@@ -568,7 +568,7 @@ prep_data <- function(data,
     fe_dat <- as.data.frame(data[["fixed_effects"]])
     fe_levels <- vapply(fe_dat, nlevels, 0L)
     if (any(fe_levels == 1)) {
-      if (ncol(fe_dat) == 1) {
+      if (ncol(fe_dat) != 1) {
         stop(
           "Can't have a fixed effect with only one group AND multiple fixed ",
           "effect variables"

--- a/tests/testthat/test-lm-robust-fes.R
+++ b/tests/testthat/test-lm-robust-fes.R
@@ -636,6 +636,12 @@ test_that("FEs work with missingness", {
     "Some observations have missingness in the fixed effects but not in the outcome or covariates."
   )
 
+  # Check to make sure with only one FE when missingness works
+  expect_warning(
+    lm_robust(Y ~ Z + X, fixed_effects = ~ B, data = datmiss, se_type = "HC2"),
+    "Some observations have missingness in the fixed effects but not in the outcome or covariates."
+  )
+
   expect_equivalent(
     tidy(ro)[ro$term %in% c("Z", "X"), ],
     tidy(rfo)[rfo$term %in% c("Z", "X"), ]
@@ -1039,6 +1045,136 @@ test_that("FEs give correct projected F-stats", {
 
 })
 
+test_that("FE matches lm_robust with one block", {
+  # In outcome
+  datmiss <- dat
+  datmiss$Y[5] <- NA
+  datmiss$oneB <- "A"
+
+  ## Classical
+  ro <- lm_robust(Y ~ Z + X, data = datmiss, se_type = "classical")
+  rfo <- lm_robust(Y ~ Z + X, fixed_effects = ~ oneB, data = datmiss, se_type = "classical")
+
+  expect_equivalent(
+    tidy(ro)[ro$term %in% c("Z", "X"), ],
+    tidy(rfo)[rfo$term %in% c("Z", "X"), ]
+  )
+
+  expect_equal(
+    ro[c("r.squared", "adj.r.squared")],
+    rfo[c("r.squared", "adj.r.squared")]
+  )
+
+  ## HC0
+  ro <- lm_robust(Y ~ Z + X, data = datmiss, se_type = "HC0")
+  rfo <- lm_robust(Y ~ Z + X, fixed_effects = ~ oneB, data = datmiss, se_type = "HC0")
+
+  expect_equivalent(
+    tidy(ro)[ro$term %in% c("Z", "X"), ],
+    tidy(rfo)[rfo$term %in% c("Z", "X"), ]
+  )
+
+  expect_equal(
+    ro[c("r.squared", "adj.r.squared")],
+    rfo[c("r.squared", "adj.r.squared")]
+  )
+
+  ## HC1
+  ro <- lm_robust(Y ~ Z + X, data = datmiss, se_type = "HC1")
+  rfo <- lm_robust(Y ~ Z + X, fixed_effects = ~ oneB, data = datmiss, se_type = "HC1")
+
+  expect_equivalent(
+    tidy(ro)[ro$term %in% c("Z", "X"), ],
+    tidy(rfo)[rfo$term %in% c("Z", "X"), ]
+  )
+
+  expect_equal(
+    ro[c("r.squared", "adj.r.squared")],
+    rfo[c("r.squared", "adj.r.squared")]
+  )
+
+  ## HC2
+  ro <- lm_robust(Y ~ Z + X, data = datmiss, se_type = "HC2")
+  rfo <- lm_robust(Y ~ Z + X, fixed_effects = ~ oneB, data = datmiss, se_type = "HC2")
+
+  expect_equivalent(
+    tidy(ro)[ro$term %in% c("Z", "X"), ],
+    tidy(rfo)[rfo$term %in% c("Z", "X"), ]
+  )
+
+  expect_equal(
+    ro[c("r.squared", "adj.r.squared")],
+    rfo[c("r.squared", "adj.r.squared")]
+  )
+
+  ## HC3
+  ro <- lm_robust(Y ~ Z + X, data = datmiss, se_type = "HC3")
+  rfo <- lm_robust(Y ~ Z + X, fixed_effects = ~ oneB, data = datmiss, se_type = "HC3")
+  lfo <- lm(Y ~ Z + X, data = datmiss)
+
+  expect_equivalent(
+    tidy(ro)[ro$term %in% c("Z", "X"), ],
+    tidy(rfo)[rfo$term %in% c("Z", "X"), ]
+  )
+
+  expect_equivalent(
+    tidy(rfo)[rfo$term %in% c("Z", "X"), c("std.error")],
+    sqrt(diag(sandwich::vcovHC(lfo, type = "HC3"))[2:3])
+  )
+
+  expect_equal(
+    ro[c("r.squared", "adj.r.squared")],
+    rfo[c("r.squared", "adj.r.squared")]
+  )
+
+  ## CR0
+  ro <- lm_robust(Y ~ Z + X, clusters = cl, data = datmiss, se_type = "CR0")
+  rfo <- lm_robust(Y ~ Z + X, fixed_effects = ~ oneB, clusters = cl, data = datmiss, se_type = "CR0")
+
+  expect_equivalent(
+    tidy(ro)[ro$term %in% c("Z", "X"), ],
+    tidy(rfo)[rfo$term %in% c("Z", "X"), ]
+  )
+
+  expect_equal(
+    ro[c("r.squared", "adj.r.squared")],
+    rfo[c("r.squared", "adj.r.squared")]
+  )
+
+  ## CR stata
+  ro <- lm_robust(Y ~ Z + X, clusters = cl, data = datmiss, se_type = "stata")
+  rfo <- lm_robust(Y ~ Z + X, fixed_effects = ~ oneB, clusters = cl, data = datmiss, se_type = "stata")
+
+  expect_equivalent(
+    tidy(ro)[ro$term %in% c("Z", "X"), ],
+    tidy(rfo)[rfo$term %in% c("Z", "X"), ]
+  )
+
+  expect_equal(
+    ro[c("r.squared", "adj.r.squared")],
+    rfo[c("r.squared", "adj.r.squared")]
+  )
+
+  ## CR2
+  ro <- lm_robust(Y ~ Z + X, clusters = cl, data = datmiss, se_type = "CR2")
+  rfo <- lm_robust(Y ~ Z + X, fixed_effects = ~ oneB, clusters = cl, data = datmiss, se_type = "CR2")
+
+  expect_equivalent(
+    tidy(ro)[ro$term %in% c("Z", "X"), ],
+    tidy(rfo)[rfo$term %in% c("Z", "X"), ]
+  )
+
+  expect_equal(
+    ro[c("r.squared", "adj.r.squared")],
+    rfo[c("r.squared", "adj.r.squared")]
+  )
+
+  ## Error when combined with other blocks
+  expect_error(
+    lm_robust(Y ~ Z + X, fixed_effects = ~ oneB + B, data = datmiss),
+    "Can't have a fixed effect with only one group AND multiple fixed effect variables"
+  )
+})
 
 test_that("Handle perfect fits appropriately", {
   dat$Bsingle <- c(1, 2, rep(3:4, each = 9))


### PR DESCRIPTION
Solves Macartan's problem about wanting support for their being a fixed effect with only one group. Note for now we do not support a fixed effect with only one group if there are multiple fixed effect variables.

Also solves a bug where if there is one fixed effect variable and missingness, `clean_model_data` returns a vector rather than a matrix for the fixed effects.