### PR TITLE
Fix mlm off diag

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# estimatr 0.11.0
+
+* Fixed bug preventing integration with latest version of `margins`
+* Fixed bug pointed out by James Pustejovsky via the `sandwich` version 2.5-0 and off-diagonal blocks of multivariate regression vcov matrices
+
 # estimatr 0.10.0
 
 * Changed names of confidence interval columns in tidied data from `ci.lower` and `ci.upper` to `conf.low` and `conf.high` to be in line with other tidy methods

--- a/src/lm_robust_helper.cpp
+++ b/src/lm_robust_helper.cpp
@@ -323,8 +323,14 @@ List lm_variance(Eigen::Map<Eigen::MatrixXd>& X,
       }
       // Rcout << "temp_omega:" << std::endl << temp_omega << std::endl;
 
+
       for (int m = 0; m < ny; m++) {
-        half_meat.block(0, r*m, n, r) = X.leftCols(r).array().colwise() * temp_omega.col(m).array().sqrt();
+        if (ny > 1) {
+          // Preserve signs for off-diagonal vcov blocks in mlm
+          half_meat.block(0, r*m, n, r) =  X.leftCols(r).array().colwise() * (ei.col(m).array().sign() * temp_omega.col(m).array().sqrt());
+        } else {
+          half_meat.block(0, r*m, n, r) =  X.leftCols(r).array().colwise() * temp_omega.col(m).array().sqrt();
+        }
       }
 
     } else {


### PR DESCRIPTION
As per fix in Sandwich v2.5-0 fix in `vcovHC.mlm`. 

From https://cran.r-project.org/web/packages/sandwich/NEWS:

```
Fix of a bug in vcovHC.mlm (reported by James Pustejovsky). The off-diagonal
    values of the vcovHC were computed without preserving the sign of the
    underlying residuals. This issue did not affect the diagonal because
    the underlying cross product amounts to squaring all values - but it does
    matter for the off-diagonal. Also, type="const" was disabled in this
    scenario and vcov(...) is simply used instead of vcovHC(..., type = "const")
```