### PR TITLE
Fixes bugs/ambiguities in lm_lin

### DIFF
--- a/R/estimatr_lm_lin.R
+++ b/R/estimatr_lm_lin.R
@@ -279,8 +279,15 @@ lm_lin <- function(formula,
 
   original_covar_names <- colnames(demeaned_covars)
 
-  # Change name of centered covariates to end in bar
-  colnames(demeaned_covars) <- paste0(colnames(demeaned_covars), "_c")
+  # Change name of centered covariates to end in "_c"
+  # If covar name has `:` or a `(` not in the first position,
+  # wrap the whole var name in parentheses first
+  colnames(demeaned_covars) <- paste0(
+    ifelse(grepl("\\:|(^.+\\()", colnames(demeaned_covars)),
+           paste0("(", colnames(demeaned_covars), ")"),
+           colnames(demeaned_covars)),
+    "_c"
+  )
 
   n_treat_cols <- ncol(treatment)
   n_covars <- ncol(demeaned_covars)

--- a/R/estimatr_lm_lin.R
+++ b/R/estimatr_lm_lin.R
@@ -219,8 +219,8 @@ lm_lin <- function(formula,
   data <- enquo(data)
   model_data <- clean_model_data(data = data, datargs)
 
-  outcome <- model_data$outcome
-  n <- length(outcome)
+  outcome <- as.matrix(model_data$outcome)
+  n <- nrow(outcome)
   design_matrix <- model_data$design_matrix
   weights <- model_data$weights
   cluster <- model_data$cluster

--- a/tests/testthat/test-lm-lin.R
+++ b/tests/testthat/test-lm-lin.R
@@ -381,3 +381,25 @@ test_that("lm_lin properly renames trickily named variables", {
       "am:wt_c", "am:cyl_c", "am:(log(wt))_c", "am:(wt:cyl)_c")
   )
 })
+
+test_that("lm_lin works with multiple outcomes", {
+
+  lmpg <- lm_lin(mpg ~ am, ~ cyl, mtcars)
+  lwt <- lm_lin(wt ~ am, ~ cyl, mtcars)
+  lboth <- lm_lin(cbind(mpg, wt) ~ am, ~ cyl, mtcars)
+
+  expect_equivalent(
+    tidy(lmpg),
+    tidy(lboth)[1:4, ]
+  )
+
+  expect_equivalent(
+    tidy(lwt),
+    tidy(lboth)[5:8, ]
+  )
+
+  expect_equivalent(
+    lboth$fstatistic[1:2],
+    c(lmpg$fstatistic[1], lwt$fstatistic[1])
+  )
+})

--- a/tests/testthat/test-lm-lin.R
+++ b/tests/testthat/test-lm-lin.R
@@ -368,3 +368,16 @@ test_that("weighted lm_lin same as with two covar sampling view", {
     coef(lmw2o)["am"]
   )
 })
+
+test_that("lm_lin properly renames trickily named variables", {
+
+  # lm_lin should add parentheses around variables that have colons in their name
+  # or that have parentheses in the name that are not in the first position
+  lo <- lm_lin(mpg ~ am, ~ wt*cyl + log(wt), mtcars)
+
+  expect_equal(
+    lo$term,
+    c("(Intercept)", "am", "wt_c", "cyl_c", "(log(wt))_c", "(wt:cyl)_c",
+      "am:wt_c", "am:cyl_c", "am:(log(wt))_c", "am:(wt:cyl)_c")
+  )
+})


### PR DESCRIPTION
Two minor changes to `lm_lin`:

- Closes issue #253 by clearing up the ambiguity about how we are centering interacted variables (we are indeed doing `Z:(x1:x2)_c`)
- Closes issue #249 by forcing outcome to be matrix and using `nrow` to get number of obs rather than `length(outcome)`