### PR TITLE
Bump version to 0.12 for CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: estimatr
 Type: Package
 Title: Fast Estimators for Design-Based Inference
-Version: 0.11.1
-Date: 2018-07-11
+Version: 0.12
+Date: 2018-09-05
 Authors@R: c(person("Graeme", "Blair", email = "graeme.blair@ucla.edu", role = c("aut", "cre")),
              person("Jasper", "Cooper", email = "jjc2247@columbia.edu", role = c("aut")),
              person("Alexander", "Coppock", email = "alex.coppock@yale.edu", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,4 @@
-# estimatr 0.11
-
-### estimatr 0.11.1
+# estimatr 0.12.0
 
 * Fixed ambiguity about how interacted covariates were centered in `lm_lin`
 * A series of fixes for bugs that occurred with multiple outcomes (multivariate regression):
@@ -8,9 +6,6 @@
   * Fixed bugs in `lm_lin` preventing multivariate regression
   * Fixed bug that truncated degrees of freedom with "CR2"  standard errors
   * Fixed bug that returned incorrect R-squared for the second or later outcomes
-
-### estimatr 0.11.0
-
 * Fixed bug preventing integration with latest version of `margins`
 
 # estimatr 0.10.0


### PR DESCRIPTION
All this does is bump up the version for submission. One concern I have is that the versioning is a bit weird. We lose the history of the intermediate versions, which isn't ideal, however, removing them preserves the NEWS.md as a version history for CRAN, which is what most people are going to use.

Not sure what to do. Maybe there should be a secondary NEWS.md that is more complete?