### PR TITLE
Add .onLoad warning for old versions of broom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ matrix:
   include:
     - os: linux
       r: release
+      r_github_packages: tidymodels/broom
+
+    - os: linux
+      r: release
+      r_packages: broom
 
     - os: linux
       r: 3.4

--- a/R/S3_tidy.R
+++ b/R/S3_tidy.R
@@ -2,7 +2,7 @@
 #' @export
 generics::tidy
 
-tidy_data_frame <- function(object, ...) {
+tidy_data_frame <- function(x, ...) {
   vec_cols <- c(
     "coefficients",
     "std.error",
@@ -13,13 +13,13 @@ tidy_data_frame <- function(object, ...) {
     "df"
   )
 
-  tidy_mat <- do.call("cbind", lapply(object[vec_cols], as.vector))
+  tidy_mat <- do.call("cbind", lapply(x[vec_cols], as.vector))
   vec_cols[vec_cols == "coefficients"] <- "estimate"
   colnames(tidy_mat) <- vec_cols
   return_frame <- data.frame(
-    term = object[["term"]],
+    term = x[["term"]],
     tidy_mat,
-    outcome = rep(object[["outcome"]], each = length(object[["term"]])),
+    outcome = rep(x[["outcome"]], each = length(x[["term"]])),
     stringsAsFactors = FALSE
   )
 
@@ -28,9 +28,9 @@ tidy_data_frame <- function(object, ...) {
   return(return_frame)
 }
 
-warn_singularities <- function(object) {
-  if (object$rank < object$k) {
-    singularities <- object$k - object$rank
+warn_singularities <- function(x) {
+  if (x$rank < x$k) {
+    singularities <- x$k - x$rank
     what <- ifelse(singularities > 1, " coefficients ", " coefficient ")
     message(
       singularities, what,
@@ -46,16 +46,16 @@ warn_singularities <- function(object) {
 #' errors, confidence intervals, p-values, degrees of freedom, and the
 #' name of the outcome variable
 #'
-#' @param object An object returned by one of the estimators
+#' @param x An x returned by one of the estimators
 #' @param ... extra arguments (not used)
 #'
 #' @export
 #' @family estimatr tidiers
 #' @seealso [generics::tidy()], [estimatr::lm_robust()], [estimatr::iv_robust()],  [estimatr::difference_in_means()], [estimatr::horvitz_thompson()]
 #' @md
-tidy.lm_robust <- function(object, ...) {
-  warn_singularities(object)
-  tidy_data_frame(object)
+tidy.lm_robust <- function(x, ...) {
+  warn_singularities(x)
+  tidy_data_frame(x)
 }
 
 #' @rdname estimatr_tidiers
@@ -63,9 +63,9 @@ tidy.lm_robust <- function(object, ...) {
 #'
 #' @export
 #' @family estimatr tidiers
-tidy.iv_robust <- function(object, ...) {
-  warn_singularities(object)
-  tidy_data_frame(object)
+tidy.iv_robust <- function(x, ...) {
+  warn_singularities(x)
+  tidy_data_frame(x)
 }
 
 #' @rdname estimatr_tidiers

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,4 @@
-# This code modified from
+# Some of this is code modified from
 # https://github.com/atahk/bucky/blob/master/R/zzz.R (GPL 3.0)
 .onLoad <- function(libname, pkgname) {
   if (suppressWarnings(requireNamespace("texreg", quietly = TRUE))) {
@@ -14,13 +14,16 @@
               definition = extract.iv_robust
     )
   }
+  invisible()
+}
 
+#' @importFrom utils packageVersion
+.onAttach <- function(libname, pkgname) {
   if (isNamespaceLoaded("broom") && packageVersion("broom") <= "0.5.0") {
     packageStartupMessage(
       "Warning: the `broom` package version 0.5.0 or earlier is loaded.\n",
       "Please upgrade `broom` or `tidy` methods may not work as expected."
     )
   }
-
   invisible()
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -14,5 +14,13 @@
               definition = extract.iv_robust
     )
   }
+
+  if (isNamespaceLoaded("broom") && packageVersion("broom") <= "0.5.0") {
+    packageStartupMessage(
+      "Warning: the `broom` package version 0.5.0 or earlier is loaded.\n",
+      "Please upgrade `broom` or `tidy` methods may not work as expected."
+    )
+  }
+
   invisible()
 }

--- a/tests/testthat/test-zzz.R
+++ b/tests/testthat/test-zzz.R
@@ -10,3 +10,25 @@ test_that("onLoad makes generics if texreg is present", {
   expect_null(.onLoad("estimatr", "estimatr"))
   environment(.onLoad) <- e
 })
+
+test_that(".onLoad does not message if new version of 'broom' is loaded", {
+  skip_if_not_installed("broom", minimum_version = "0.5.0.9000")
+  library(broom)
+  expect_silent(.onLoad("estimatr", "estimatr"))
+
+  expect_is(
+    tidy(lm_robust(mpg ~ hp, mtcars)),
+    "data.frame"
+  )
+})
+
+
+test_that(".onLoad message if old version of 'broom' is installed", {
+  skip_if_not_installed("broom")
+  skip_if(packageVersion("broom") > "0.5.0")
+  library(broom)
+  expect_message(
+    .onLoad("estimatr", "estimatr"),
+    "the `broom` package version 0.5.0 or earlier is loaded"
+  )
+})


### PR DESCRIPTION
This PR will `packageStartupMessage` if `broom` version <= 0.5.0, the current CRAN version, is attached. If they attach broom afterwards, there's no guarantee.

Hopefully the `broom` that relies on `generics` will be on CRAN soon.

This also tests the message is silent if the right version of `broom` is installed and that it messages with the old version. Travis hopefully is set up to test both on Linux, release R.