### PR TITLE
WIP - Prep v0.16 for CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: estimatr
 Type: Package
 Title: Fast Estimators for Design-Based Inference
-Version: 0.15
+Version: 0.16
 Date: 2019-02-27
 Authors@R: c(person("Graeme", "Blair", email = "graeme.blair@ucla.edu", role = c("aut", "cre")),
              person("Jasper", "Cooper", email = "jjc2247@columbia.edu", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,9 @@
-# estimatr 0.15.0 (GitHub)
+# estimatr 0.16.0
 
 * Add `diagnostics` to `iv_robust()`
 * Add `glance()` methods for all estimators
 
-# estimatr 0.14.0 (CRAN)
+# estimatr 0.14.0
 
 * Removes `broom` hack for `tidy` method and instead relies on importing `generics`
 

--- a/R/estimatr_lm_lin.R
+++ b/R/estimatr_lm_lin.R
@@ -202,13 +202,10 @@ lm_lin <- function(formula,
   # Get design matrix including `covariates` for centering
   # ----------
 
-  full_formula <-
-    update(
-      formula,
-      reformulate(
-        c(".", labels(cov_terms), response = ".")
-      )
-    )
+  full_formula <- update(
+    formula,
+    reformulate(c(".", labels(cov_terms)))
+  )
 
   datargs <- enquos(
     formula = full_formula,

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,15 +16,15 @@ knitr::opts_chunk$set(
 options(digits = 2)
 ```
 
-[![CRAN Status](https://www.r-pkg.org/badges/version/estimatr)](https://cran.r-project.org/package=estimatr)
-[![Travis-CI Build Status](https://travis-ci.org/DeclareDesign/estimatr.svg?branch=master)](https://travis-ci.org/DeclareDesign/estimatr)
+[![CRAN Status](https://r-pkg.org/badges/version/estimatr)](https://cran.r-project.org/package=estimatr)
+[![Travis-CI Build Status](https://travis-ci.com/DeclareDesign/estimatr.svg?branch=master)](https://travis-ci.com/DeclareDesign/estimatr)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/DeclareDesign/estimatr?branch=master&svg=true)](https://ci.appveyor.com/project/DeclareDesign/estimatr)
 [![Coverage Status](https://coveralls.io/repos/github/DeclareDesign/estimatr/badge.svg?branch=master)](https://coveralls.io/github/DeclareDesign/estimatr?branch=master)
 ![CRAN downloads](http://cranlogs.r-pkg.org/badges/grand-total/estimatr)
 
-**estimatr** is an `R` package providing a range of commonly-used linear estimators, designed for speed and for ease-of-use. Users can easily recover robust, cluster-robust, and other design appropriate estimates. We include two functions that implement means estimators, `difference_in_means()` and `horvitz_thompson()`, and three linear regression estimators, `lm_robust()`, `lm_lin()`, and `iv_robust()`. In each case, users can choose an estimator to reflect cluster-randomized, block-randomized, and block-and-cluster-randomized designs. The [Getting Started Guide](/r/estimatr/articles/getting-started.html) describes each estimator provided by **estimatr** and how it can be used in your analysis.
+**estimatr** is an `R` package providing a range of commonly-used linear estimators, designed for speed and for ease-of-use. Users can easily recover robust, cluster-robust, and other design appropriate estimates. We include two functions that implement means estimators, `difference_in_means()` and `horvitz_thompson()`, and three linear regression estimators, `lm_robust()`, `lm_lin()`, and `iv_robust()`. In each case, users can choose an estimator to reflect cluster-randomized, block-randomized, and block-and-cluster-randomized designs. The [Getting Started Guide](https://declaredesign.org/r/estimatr/articles/getting-started.html) describes each estimator provided by **estimatr** and how it can be used in your analysis.
 
-You can also see the multiple ways you can [get regression tables out of estimatr](/r/estimatr/articles/regression-tables.html) using commonly used `R` packages such as `texreg` and `stargazer`. Fast estimators also enable fast simulation of research designs to learn about their properties (see [DeclareDesign](https://declaredesign.org)).
+You can also see the multiple ways you can [get regression tables out of estimatr](https://declaredesign.org/r/estimatr/articles/regression-tables.html) using commonly used `R` packages such as `texreg` and `stargazer`. Fast estimators also enable fast simulation of research designs to learn about their properties (see [DeclareDesign](https://declaredesign.org)).
 
 ## Installing estimatr
 
@@ -78,7 +78,7 @@ The [Getting Started Guide](/r/estimatr/articles/getting-started.html) has more 
 
 ## Fast to use
 
-Getting estimates and robust standard errors is also faster than it used to be. Compare our package to using `lm()` and the `sandwich` package to get HC2 standard errors. More speed comparisons are available [here](/r/estimatr/articles/benchmarking-estimatr.html). Furthermore, with many blocks (or fixed effects), users can use the `fixed_effects` argument of `lm_robust` with HC1 standard errors to greatly improve estimation speed. More on [fixed effects here](/r/estimatr/articles/absorbing-fixed-effects.html).
+Getting estimates and robust standard errors is also faster than it used to be. Compare our package to using `lm()` and the `sandwich` package to get HC2 standard errors. More speed comparisons are available [here](https://declaredesign.org/r/estimatr/articles/benchmarking-estimatr.html). Furthermore, with many blocks (or fixed effects), users can use the `fixed_effects` argument of `lm_robust` with HC1 standard errors to greatly improve estimation speed. More on [fixed effects here](https://declaredesign.org/r/estimatr/articles/absorbing-fixed-effects.html).
 
 ```{r, echo=-1}
 set.seed(1)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ estimatr: Fast Estimators for Design-Based Inference
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
 [![CRAN
-Status](https://www.r-pkg.org/badges/version/estimatr)](https://cran.r-project.org/package=estimatr)
+Status](https://r-pkg.org/badges/version/estimatr)](https://cran.r-project.org/package=estimatr)
 [![Travis-CI Build
-Status](https://travis-ci.com/DeclareDesign/estimatr.svg?branch=master)
+Status](https://travis-ci.com/DeclareDesign/estimatr.svg?branch=master)](https://travis-ci.com/DeclareDesign/estimatr)
 [![AppVeyor Build
 Status](https://ci.appveyor.com/api/projects/status/github/DeclareDesign/estimatr?branch=master&svg=true)](https://ci.appveyor.com/project/DeclareDesign/estimatr)
 [![Coverage
@@ -21,15 +21,16 @@ We include two functions that implement means estimators,
 regression estimators, `lm_robust()`, `lm_lin()`, and `iv_robust()`. In
 each case, users can choose an estimator to reflect cluster-randomized,
 block-randomized, and block-and-cluster-randomized designs. The [Getting
-Started Guide](/r/estimatr/articles/getting-started.html) describes each
-estimator provided by **estimatr** and how it can be used in your
-analysis.
+Started
+Guide](https://declaredesign.org/r/estimatr/articles/getting-started.html)
+describes each estimator provided by **estimatr** and how it can be used
+in your analysis.
 
 You can also see the multiple ways you can [get regression tables out of
-estimatr](/r/estimatr/articles/regression-tables.html) using commonly
-used `R` packages such as `texreg` and `stargazer`. Fast estimators also
-enable fast simulation of research designs to learn about their
-properties (see [DeclareDesign](https://declaredesign.org)).
+estimatr](https://declaredesign.org/r/estimatr/articles/regression-tables.html)
+using commonly used `R` packages such as `texreg` and `stargazer`. Fast
+estimators also enable fast simulation of research designs to learn
+about their properties (see [DeclareDesign](https://declaredesign.org)).
 
 ## Installing estimatr
 
@@ -111,11 +112,11 @@ information about what each estimator is doing under the hood.
 Getting estimates and robust standard errors is also faster than it used
 to be. Compare our package to using `lm()` and the `sandwich` package to
 get HC2 standard errors. More speed comparisons are available
-[here](/r/estimatr/articles/benchmarking-estimatr.html). Furthermore,
-with many blocks (or fixed effects), users can use the `fixed_effects`
-argument of `lm_robust` with HC1 standard errors to greatly improve
-estimation speed. More on [fixed effects
-here](/r/estimatr/articles/absorbing-fixed-effects.html).
+[here](https://declaredesign.org/r/estimatr/articles/benchmarking-estimatr.html).
+Furthermore, with many blocks (or fixed effects), users can use the
+`fixed_effects` argument of `lm_robust` with HC1 standard errors to
+greatly improve estimation speed. More on [fixed effects
+here](https://declaredesign.org/r/estimatr/articles/absorbing-fixed-effects.html).
 
 ``` r
 dat <- data.frame(X = matrix(rnorm(2000*50), 2000), y = rnorm(2000))
@@ -135,7 +136,7 @@ mb <- microbenchmark(
 | estimatr      | median run-time (ms) |
 | :------------ | -------------------: |
 | estimatr      |                   22 |
-| lm + sandwich |                   45 |
+| lm + sandwich |                   43 |
 
 -----
 

--- a/tests/testthat/test-lm-lin.R
+++ b/tests/testthat/test-lm-lin.R
@@ -310,6 +310,13 @@ test_that("Test LM Lin", {
     lmlo$term,
     c("z", "X1_c", "z:X1_c")
   )
+
+  # behaves correctly with "odd" covariates (see issue #283)
+  lmlo <- lm_lin(Y ~ z, ~ is.na(X1), data = dat)
+  expect_equal(
+    lmlo$term,
+    c("(Intercept)", "z", "(is.na(X1)TRUE)_c", "z:(is.na(X1)TRUE)_c")
+  )
 })
 
 test_that("lm_lin same as sampling perspective", {


### PR DESCRIPTION
- Hardcodes readme urls so it works on github and website (closes #273)
- Fixes unnecessary duplication of treatment variable in `lm_lin` (closes #283)
