### PR TITLE
CRAN patch and other small changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: estimatr
 Type: Package
 Title: Fast Estimators for Design-Based Inference
-Version: 0.16.1
-Date: 2019-03-05
+Version: 0.18.0
+Date: 2019-05-25
 Authors@R: c(person("Graeme", "Blair", email = "graeme.blair@ucla.edu", role = c("aut", "cre")),
              person("Jasper", "Cooper", email = "jjc2247@columbia.edu", role = c("aut")),
              person("Alexander", "Coppock", email = "alex.coppock@yale.edu", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,10 @@
-# estimatr 0.16.1
+# estimatr 0.18.0
 
 * Fixed bug where collinear covariates caused fixed effects estimator to crash  (issue #294)
 * Added `glance.lh_robust()` and fixed some issues with printing and summarizing `lh_robust()` objects (issues #295 and #296)
+* Fixes CRAN errors in testing with new `clubSandwich` package
 
-# estimatr 0.16.0 (latest CRAN)
+# estimatr 0.16.0
 
 * Add `diagnostics` to `iv_robust()`
 * Add `glance()` methods for all estimators

--- a/R/estimatr_lm_robust.R
+++ b/R/estimatr_lm_robust.R
@@ -69,6 +69,9 @@
 #' multiple fixed effect variables (e.g. if you specify both "year" and "country" fixed effects
 #' with an unbalanced panel where one year you only have data for one country).
 #'
+#' As with \code{`lm()`}, multivariate regression (multiple outcomes) will only admit
+#' observations into the estimation that have no missingness on any outcome.
+#'
 #' @return An object of class \code{"lm_robust"}.
 #'
 #' The post-estimation commands functions \code{summary} and \code{\link{tidy}}

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,11 @@
+## Test environments
+* local OS X install
+* travis-ci ubuntu (3.4, 3.5, 3.6)
+* travis-ci OS X (3.4, 3.5)
+* Appveyor windows (3.4, 3.5)
+
+Passes with only notes about package size.
+
+However, the main purpose of this update is to respond to CRAN errors due to updates to clubSandwich. These have been resolved.
+
+Unfortunately, other outstanding errors with some memory issues on the CRAN solaris boxes have not been resolved due to an inability to test package updates in a stable Solaris environment (r-hub's facilities are not working). We are still working on this issue.

--- a/man/lm_robust.Rd
+++ b/man/lm_robust.Rd
@@ -133,6 +133,9 @@ standard error estimators. Be wary when specifying fixed effects that may result
 in perfect fits for some observations or if there are intersecting groups across
 multiple fixed effect variables (e.g. if you specify both "year" and "country" fixed effects
 with an unbalanced panel where one year you only have data for one country).
+
+As with \code{`lm()`}, multivariate regression (multiple outcomes) will only admit
+observations into the estimation that have no missingness on any outcome.
 }
 \examples{
 library(fabricatr)

--- a/tests/testthat/test-iv-robust.R
+++ b/tests/testthat/test-iv-robust.R
@@ -240,7 +240,7 @@ test_that("iv_robust matches AER + clubSandwich", {
                                         cluster = dat$clust,
                                         test = ifelse(se_type == "CR2", "Satterthwaite", "naive-t"))
 
-    cols <- if (se_type == "CR2") c("estimate", "std.error", "df", "p.value") else c("estimate", "std.error", "p.value")
+    cols <- if (se_type == "CR2") c("estimate", "std.error", "statistic", "df", "p.value") else c("estimate", "std.error", "statistic", "p.value")
 
     expect_equivalent(
       as.matrix(tidy(ivcr)[, cols]),


### PR DESCRIPTION
Respond to CRAN notice to fix errors:

1) Tests fail due to update in clubSandwich **(resolved)**
2) Same segfaults on Solaris in demeanMat, which I have been unable to resolve despite trying to silo the problem and rewriting the code many times **(unresolved)**

Make other small changes:

1) add note about missingness in mlm (closes #299)  **(resolved)**