### PR TITLE
Added emmeans support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Suggests:
     randomizr (>= 0.16),
     AER,
     clubSandwich,
+    emmeans (>= 1.4),
     ivpack,
     lfe,
     margins,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,8 @@ Authors@R: c(person("Graeme", "Blair", email = "graeme.blair@ucla.edu", role = c
              person("Macartan", "Humphreys", email = "macartan@gmail.com", role = c("aut")),
              person("Luke", "Sonnet", email = "luke.sonnet@gmail.com", role = c("aut")),
              person("Neal", "Fultz", email = "nfultz@gmail.com", role = c("ctb")),
-             person("Lily", "Medina", email = "lilymiru@gmail.com", role = c("ctb")))
+             person("Lily", "Medina", email = "lilymiru@gmail.com", role = c("ctb")),
+             person("Russell", "Lenth", email = "russell-lenth@uiowa.edu", role = c("ctb")))
 Description: Fast procedures for small set of commonly-used, design-appropriate estimators with robust standard errors and confidence intervals. Includes estimators for linear regression, instrumental variables regression, difference-in-means, Horvitz-Thompson estimation, and regression improving precision of experimental estimates by interacting treatment with centered pre-treatment covariates introduced by Lin (2013) <doi:10.1214/12-AOAS583>.
 URL: https://declaredesign.org/r/estimatr/, https://github.com/DeclareDesign/estimatr
 BugReports: https://github.com/DeclareDesign/estimatr/issues
@@ -30,6 +31,7 @@ Suggests:
     AER,
     clubSandwich,
     emmeans (>= 1.4),
+    estimability,
     ivpack,
     lfe,
     margins,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: estimatr
 Type: Package
 Title: Fast Estimators for Design-Based Inference
-Version: 0.18.0
-Date: 2019-05-25
+Version: 0.19.0
+Date: 2019-08-07
 Authors@R: c(person("Graeme", "Blair", email = "graeme.blair@ucla.edu", role = c("aut", "cre")),
              person("Jasper", "Cooper", email = "jjc2247@columbia.edu", role = c("aut")),
              person("Alexander", "Coppock", email = "alex.coppock@yale.edu", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# estimatr 0.18.0
+# estimatr 0.19.0 (dev)
+
+* Added support for `emmeans` (thanks @rvlenth)!
+
+# estimatr 0.18.0 (CRAN)
 
 * Fixed bug where collinear covariates caused fixed effects estimator to crash  (issue #294)
 * Added `glance.lh_robust()` and fixed some issues with printing and summarizing `lh_robust()` objects (issues #295 and #296)

--- a/R/S3_emmeans.R
+++ b/R/S3_emmeans.R
@@ -2,42 +2,40 @@
 #
 # Note: the recover_data and emm_basis methods are registered dynamically
 #   (see zzz.R). So these functions are not exported
-#
-# Apologies from RVL: I use "=" rather than "<-" for top-level assignment
 
-recover_data.lm_robust = function(object, ...) {
-  data = getS3method("recover_data", "lm")(object, ...)
+recover_data.lm_robust <- function(object, ...) {
+  data <- getS3method("recover_data", "lm")(object, ...)
   if (object$rank < object$k)  # rank-deficient. Need to pass dataset to emm_basis
-    attr(data, "pass.it.on") = TRUE
+    attr(data, "pass.it.on") <- TRUE
   data
 }
 
-emm_basis.lm_robust = function(object, trms, xlev, grid, ...) {
+emm_basis.lm_robust <- function(object, trms, xlev, grid, ...) {
   # coef() works right for lm but coef.aov tosses out NAs
-  bhat = coef(object)
-  n.mult = ifelse(is.matrix(bhat), ncol(bhat), 1)  # columns in mult response
-  m = suppressWarnings(model.frame(trms, grid, na.action = na.pass, xlev = xlev))
-  X = model.matrix(trms, m, contrasts.arg = object$contrasts)
-  V = emmeans::.my.vcov(object, ...)
+  bhat <- coef(object)
+  n.mult <- ifelse(is.matrix(bhat), ncol(bhat), 1)  # columns in mult response
+  m <- suppressWarnings(model.frame(trms, grid, na.action = na.pass, xlev = xlev))
+  X <- model.matrix(trms, m, contrasts.arg = object$contrasts)
+  V <- emmeans::.my.vcov(object, ...)
 
   if (!anyNA(bhat))
-    nbasis = estimability::all.estble
+    nbasis <- estimability::all.estble
   else {
-    desmat = model.matrix(trms, data = attr(object, "data"))
-    nbasis = estimability::nonest.basis(desmat)
+    desmat <- model.matrix(trms, data = attr(object, "data"))
+    nbasis <- estimability::nonest.basis(desmat)
   }
-  misc = list()
+  misc <- list()
   if (n.mult > 1) { # multivariate case. Need to expand some matrices
-    eye = diag(n.mult)
-    X = kronecker(eye, X)
-    nbasis = kronecker(eye, nbasis)
+    eye <- diag(n.mult)
+    X <- kronecker(eye, X)
+    nbasis <- kronecker(eye, nbasis)
     if(is.null(colnames(bhat)))
-      colnames(bhat) = seq_len(n.mult)
-    misc$ylevs = list(rep.meas = colnames(bhat))
-    bhat = as.numeric(bhat) # stretch coefs into a vector
+      colnames(bhat) <- seq_len(n.mult)
+    misc$ylevs <- list(rep.meas = colnames(bhat))
+    bhat <- as.numeric(bhat) # stretch coefs into a vector
   }
-  dfargs = list(df = object$df.residual)
-  dffun = function(k, dfargs) dfargs$df
+  dfargs <- list(df = object$df.residual)
+  dffun <- function(k, dfargs) dfargs$df
   list(X = X, bhat = bhat, nbasis = nbasis, V = V,
        dffun = dffun, dfargs = dfargs, misc = misc)
 }

--- a/R/S3_emmeans.R
+++ b/R/S3_emmeans.R
@@ -1,0 +1,43 @@
+### Support for emmeans package
+#
+# Note: the recover_data and emm_basis methods are registered dynamically
+#   (see zzz.R). So these functions are not exported
+#
+# Apologies from RVL: I use "=" rather than "<-" for top-level assignment
+
+recover_data.lm_robust = function(object, ...) {
+  data = getS3method("recover_data", "lm")(object, ...)
+  if (object$rank < object$k)  # rank-deficient. Need to pass dataset to emm_basis
+    attr(data, "pass.it.on") = TRUE
+  data
+}
+
+emm_basis.lm_robust = function(object, trms, xlev, grid, ...) {
+  # coef() works right for lm but coef.aov tosses out NAs
+  bhat = coef(object)
+  n.mult = ifelse(is.matrix(bhat), ncol(bhat), 1)  # columns in mult response
+  m = suppressWarnings(model.frame(trms, grid, na.action = na.pass, xlev = xlev))
+  X = model.matrix(trms, m, contrasts.arg = object$contrasts)
+  V = emmeans::.my.vcov(object, ...)
+
+  if (sum(is.na(bhat)) > 0) {
+    desmat = model.matrix(trms, data = attr(object, "data"))
+    nbasis = estimability::nonest.basis(desmat)
+  }
+  else
+    nbasis = estimability::all.estble
+  misc = list()
+  if (n.mult > 1) { # multivariate case. Need to expand some matrices
+    eye = diag(n.mult)
+    X = kronecker(eye, X)
+    nbasis = kronecker(eye, nbasis)
+    if(is.null(colnames(bhat)))
+      colnames(bhat) = seq_len(n.mult)
+    misc$ylevs = list(rep.meas = colnames(bhat))
+    bhat = as.numeric(bhat) # stretch coefs into a vector
+  }
+  dfargs = list(df = object$df.residual)
+  dffun = function(k, dfargs) dfargs$df
+  list(X = X, bhat = bhat, nbasis = nbasis, V = V,
+       dffun = dffun, dfargs = dfargs, misc = misc)
+}

--- a/R/S3_emmeans.R
+++ b/R/S3_emmeans.R
@@ -20,12 +20,12 @@ emm_basis.lm_robust = function(object, trms, xlev, grid, ...) {
   X = model.matrix(trms, m, contrasts.arg = object$contrasts)
   V = emmeans::.my.vcov(object, ...)
 
-  if (sum(is.na(bhat)) > 0) {
+  if (!anyNA(bhat))
+    nbasis = estimability::all.estble
+  else {
     desmat = model.matrix(trms, data = attr(object, "data"))
     nbasis = estimability::nonest.basis(desmat)
   }
-  else
-    nbasis = estimability::all.estble
   misc = list()
   if (n.mult > 1) { # multivariate case. Need to expand some matrices
     eye = diag(n.mult)

--- a/R/estimatr_lm_robust.R
+++ b/R/estimatr_lm_robust.R
@@ -80,7 +80,8 @@
 #' you can use the generic accessor functions \code{coef}, \code{vcov},
 #' \code{confint}, and \code{predict}. Marginal effects and uncertainty about
 #' them can be gotten by passing this object to
-#' \code{\link[margins]{margins}} from the \pkg{margins}.
+#' \code{\link[margins]{margins}} from the \pkg{margins},
+#' or to \code{emmeans} in the \pkg{emmeans} package.
 #'
 #' Users who want to print the results in TeX of HTML can use the
 #' \code{\link[texreg]{extract}} function and the \pkg{texreg} package.
@@ -204,8 +205,8 @@
 #' tidy(lm_robust(y ~ x + z, data = dat, fixed_effects = ~ blockID, se_type = "HC1"))
 #'
 #' \dontrun{
-#'   # Can also use 'margins' package if you have it installed to get
-#'   # marginal effects
+#'   # Can also use 'margins' or 'emmeans' package if you have them installed
+#'   # to get marginal effects
 #'   library(margins)
 #'   lmrout <- lm_robust(y ~ x + z, data = dat)
 #'   summary(margins(lmrout))
@@ -213,6 +214,11 @@
 #'   # Can output results using 'texreg'
 #'   library(texreg)
 #'   texreg(lmrout)
+#'
+#'   # Using emmeans to obtain covariate-adjusted means
+#'   library(emmeans)
+#'   fiber.rlm <- lm_robust(strength ~ diameter + machine, data = fiber)
+#'   emmeans(fiber.rlm, "machine")
 #' }
 #'
 #' @export

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -14,6 +14,9 @@
               definition = extract.iv_robust
     )
   }
+  if(requireNamespace("emmeans", quietly = TRUE)) {
+    emmeans::.emm_register("lm_robust", pkgname)
+  }
   invisible()
 }
 

--- a/man/lm_robust.Rd
+++ b/man/lm_robust.Rd
@@ -56,7 +56,8 @@ you can use these data frames, you can use the resulting list directly, or
 you can use the generic accessor functions \code{coef}, \code{vcov},
 \code{confint}, and \code{predict}. Marginal effects and uncertainty about
 them can be gotten by passing this object to
-\code{\link[margins]{margins}} from the \pkg{margins}.
+\code{\link[margins]{margins}} from the \pkg{margins},
+or to \code{emmeans} in the \pkg{emmeans} package.
 
 Users who want to print the results in TeX of HTML can use the
 \code{\link[texreg]{extract}} function and the \pkg{texreg} package.
@@ -209,8 +210,8 @@ lm_robust(y ~ x + z, data = dat, alpha = 0.1)
 tidy(lm_robust(y ~ x + z, data = dat, fixed_effects = ~ blockID, se_type = "HC1"))
 
 \dontrun{
-  # Can also use 'margins' package if you have it installed to get
-  # marginal effects
+  # Can also use 'margins' or 'emmeans' package if you have them installed
+  # to get marginal effects
   library(margins)
   lmrout <- lm_robust(y ~ x + z, data = dat)
   summary(margins(lmrout))
@@ -218,6 +219,11 @@ tidy(lm_robust(y ~ x + z, data = dat, fixed_effects = ~ blockID, se_type = "HC1"
   # Can output results using 'texreg'
   library(texreg)
   texreg(lmrout)
+
+  # Using emmeans to obtain covariate-adjusted means
+  library(emmeans)
+  fiber.rlm <- lm_robust(strength ~ diameter + machine, data = fiber)
+  emmeans(fiber.rlm, "machine")
 }
 
 }

--- a/tests/testthat/test-lm-robust_emmeans.R
+++ b/tests/testthat/test-lm-robust_emmeans.R
@@ -1,0 +1,35 @@
+context("S3 - emmeans")
+
+library(emmeans)
+
+test_that("emmeans can work with lm_robust objects", {
+  lmr = lm_robust(mpg ~ factor(cyl) * hp + wt, data = mtcars)
+
+  rg = ref_grid(lmr)
+  expect_equal(class(rg)[1], "emmGrid")
+
+  grid = rg@grid
+  expect_equal(nrow(grid), 3)
+  expect_equal(sum(grid$.wgt.), 32)
+  expect_equal(predict(rg)[1], 17.424, tolerance = .01)
+})
+
+test_that("lm_robust multivariate model works with emmeans", {
+  lmr = lm_robust(yield ~ Block + Variety, data = emmeans::MOats)
+  emm = emmeans(lmr, "rep.meas")
+  expect_equal(summary(emm)$emmean[4], 123.4, tolerance = 0.1)
+})
+
+test_that("lm_robust model with rank deficiency works with emmeans", {
+  lmr = lm_robust(log(breaks) ~ wool * tension, data = warpbreaks, subset = -(19:30))
+  pred = predict(ref_grid(lmr))
+  expect_true(is.na(pred[5]))
+  expect_equal(length(pred), 6)
+  expect_equal(sum(is.na(pred)), 1)
+})
+
+# Not testing emmeans package capabilities per se. If we can construct the
+# reference grid correctly, we are basically OK.
+# Pretty much anything else that could fail would happen in the emmeans package,
+# not in the support methods in this package.
+

--- a/tests/testthat/test-lm-robust_emmeans.R
+++ b/tests/testthat/test-lm-robust_emmeans.R
@@ -5,32 +5,32 @@ skip_if_not(getRversion() >= "3.5.0")
 library(emmeans)
 
 test_that("emmeans can work with lm_robust objects", {
-  lmr = lm_robust(mpg ~ factor(cyl) * hp + wt, data = mtcars)
+  lmr <- lm_robust(mpg ~ factor(cyl) * hp + wt, data = mtcars)
 
-  rg = ref_grid(lmr)
+  rg <- ref_grid(lmr)
   expect_equal(class(rg)[1], "emmGrid")
 
-  grid = rg@grid
+  grid <- rg@grid
   expect_equal(nrow(grid), 3)
   expect_equal(sum(grid$.wgt.), 32)
   expect_equal(predict(rg)[1], 17.424, tolerance = .01)
 })
 
 test_that("lm_robust multivariate model works with emmeans", {
-  lmr = lm_robust(yield ~ Block + Variety, data = emmeans::MOats)
-  emm = emmeans(lmr, "rep.meas")
+  lmr <- lm_robust(yield ~ Block + Variety, data = emmeans::MOats)
+  emm <- emmeans(lmr, "rep.meas")
   expect_equal(summary(emm)$emmean[4], 123.4, tolerance = 0.1)
 })
 
 test_that("lm_robust model with rank deficiency works with emmeans", {
-  lmr = lm_robust(log(breaks) ~ wool * tension, data = warpbreaks, subset = -(19:30))
-  pred = predict(ref_grid(lmr))
+  lmr <- lm_robust(log(breaks) ~ wool * tension, data = warpbreaks, subset = -(19:30))
+  pred <- predict(ref_grid(lmr))
   expect_true(is.na(pred[5]))
   expect_equal(length(pred), 6)
   expect_equal(sum(is.na(pred)), 1)
 })
 
-# Not testing emmeans package capabilities per se. If we can construct the
+# Not testing emmeans package capabilities themselves. If we can construct the
 # reference grid correctly, we are basically OK.
 # Pretty much anything else that could fail would happen in the emmeans package,
 # not in the support methods in this package.

--- a/tests/testthat/test-lm-robust_emmeans.R
+++ b/tests/testthat/test-lm-robust_emmeans.R
@@ -1,5 +1,7 @@
 context("S3 - emmeans")
 
+skip_if_not(getRversion() >= "3.5.0")
+
 library(emmeans)
 
 test_that("emmeans can work with lm_robust objects", {

--- a/tests/testthat/test-lm-robust_emmeans.R
+++ b/tests/testthat/test-lm-robust_emmeans.R
@@ -1,7 +1,5 @@
 context("S3 - emmeans")
 
-skip_if_not(getRversion() >= "3.5.0")
-
 library(emmeans)
 
 test_that("emmeans can work with lm_robust objects", {

--- a/vignettes/emmeans-examples.Rmd
+++ b/vignettes/emmeans-examples.Rmd
@@ -1,0 +1,96 @@
+---
+title: "Examples with emmeans"
+author: "Russ Lenth"
+date: "8/3/2019"
+output: html_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+The **emmeans** package provides a variety of *post hoc* analyses such
+as obtaining estimated marginal means (EMMs) and comparisons thereof,
+displaying these results in a graph, and a number of related tasks.
+
+This vignette illustrates basic uses of **emmeans** with `lm_robust` 
+objects. For more details, refer to the **emmeans** package itself 
+and its vignettes.
+
+### A factorial experiment
+The `warpbreaks` dataset provided in base R has the results of a two-factor
+experiment. We start by fitting a model
+```{r}
+library(estimatr)
+
+warp.rlm <- lm_robust(log(breaks) ~ wool * tension, data = warpbreaks)
+```
+Typical use of `emmeans()` is to obtain predictions, or marginal means thereof,
+via a formula of the form `~ primary.variables | by.variables`:
+```{r}
+library(emmeans)
+
+emm <- emmeans(warp.rlm, ~ tension | wool)
+class(emm)
+str(emm)
+emm
+```
+These results may be plotted as side-by-side intervals or as an interaction-style plot:
+```{r}
+plot(emm)
+emmip(emm, wool ~ tension, CIs = TRUE)
+```
+
+This particular example has a response transformation. That transformation is
+detected and we may back-transform to the original scale:
+```{r}
+confint(emm, type = "response")
+```
+We may do comparisons and other contrasts:
+```{r}
+pairs(emm) # pairwise comparisons
+contrast(emm, "trt.vs.ctrl", ref = "L", type = "response", adjust = "mvt")
+```
+Note that with a log transformations, it is possible to back-transform 
+comparisons, and they become ratios. With other transformations, back-transforming
+is not possible.
+
+### Rank-deficient models
+Let's create a variation on this example where one cell is omitted:
+```{r}
+warpi.rlm <- update(warp.rlm, subset = -(37:48))
+(rgi <- ref_grid(warpi.rlm))
+summary(rgi)
+```
+Note that the empty cell is detected and flagged as non-estimable.
+
+Some additional explanation here. EMMs are based on a *reference grid*, defined
+as the grid created by all possible combinations of factor levels, together with
+the mean of each numerical predictor. The reference grid here (`rgi`) is also an
+`"emmGrid"` object just like the previous `emm`.
+The grid itself is available as a data frame via the `grid` member, and
+you can verify that the above results match those of the `predict` function
+for the model:
+```{r}
+predict(warpi.rlm, newdata = rgi@grid, se.fit = TRUE)
+```
+There is one exception for the empty cell. I will leave it as a user exercise to demonstrate that if we were to use different contrasts when fitting `warpi.rlm`,
+the predictions will be the same *except* for the empty cell.
+
+### Multivariate models
+If there is a multivariate response, it is treated as another factor that
+is crossed with the other factors in the model. To illustrate, consider
+the dataset `MOats`, provided in **emmeans**:
+```{r}
+MOats.rlm <- lm_robust(yield ~ Block + Variety, data = MOats)
+ref_grid(MOats.rlm)
+```
+By default, the pseudo-factor is named `rep.meas`, but we can change it
+if we like:
+```{r}
+emmeans(MOats.rlm, pairwise ~ nitro, mult.name = "nitro")
+```
+This illustrates an additional feature of `emmeans` that we can put a contrast method in the left side of a formula.
+
+### Afterword
+There are numerous capabilities of **emmeans** not illustrated here. See that package's
+help files and vignettes. Using `vignette("basics", "emmeans")` is a good starting point.


### PR DESCRIPTION
I have added the code needed to support the **emmeans** package for use with `lm_robust` objects. This provides a nice way (nicer than **margins**, IMHO) to obtain marginal means, etc.

The changes are:

  * in `DESCRIPTION`: Add `emmeans` and the needed version
  * new file `S3_emmeans.R`: The S3 methods needed by **emmeans**
    there is one to recover the dataset, and one that is kind of like the insides of the
    `predict` method for new data. 
  * in `estimatr_lm_robust.R`: Additions to the documentation
  * in `zzz.R`: Register the S3 methods

## Some examples:

## `warpbreaks` data (standard R dataset)
```r
library(estimatr)
library(emmeans)
warp.rlm <- lm_robust(formula = breaks ~ wool * tension, data = warpbreaks)
emmeans(warp.rlm, ~ tension | wool)
## wool = A:
##  tension emmean   SE df lower.CL upper.CL
##  L         44.6 6.03 48     32.4     56.7
##  M         24.0 2.89 48     18.2     29.8
##  H         24.6 3.42 48     17.7     31.4
## 
## wool = B:
##  tension emmean   SE df lower.CL upper.CL
##  L         28.2 3.29 48     21.6     34.8
##  M         28.8 3.14 48     22.5     35.1
##  H         18.8 1.63 48     15.5     22.1
## 
## Confidence level used: 0.95

emmip(warp.rlm, wool ~ tension, CIs = TRUE)
```

![image](https://user-images.githubusercontent.com/26777519/62414446-f5a45480-b5e0-11e9-901f-1c82f2f81338.png)

### rank-deficient model
```r
warpi.rlm <- update(warp.rlm, subset = -(37:48))
(rgi <- ref_grid(warpi.rlm))  # the reference grid used as basis for EMMs
## 'emmGrid' object with variables:
##     wool = A, B
##     tension = L, M, H

rgi@grid # the data.frame with the grid
##   wool tension .wgt.
## 1    A       L     9
## 2    B       L     9
## 3    A       M     9
## 4    B       M     0
## 5    A       H     9
## 6    B       H     6

summary(rgi)
##  wool tension prediction   SE df
##  A    L             44.6 6.03 37
##  B    L             28.2 3.29 37
##  A    M             24.0 2.89 37
##  B    M           nonEst   NA NA
##  A    H             24.6 3.42 37
##  B    H             17.3 2.20 37
# Note that the non-estimable cell is flagged as such

# compare with predict:
predict(warpi.rlm, newdata = rgi@grid, se.fit = TRUE)
## $fit
##         1         2         3         4         5         6 
## 44.555556 28.222222 24.000000  7.666667 24.555556 17.333333 
## 
## $se.fit
##        1        2        3        4        5        6 
## 6.032576 3.286241 2.886751 7.451489 3.424224 2.201010
```

### Multivariate model
```r
MOats.rlm <- lm_robust(yield ~ Block + Variety, data = MOats)
ref_grid(MOats.rlm)
## 'emmGrid' object with variables:
##     Block = VI, V, III, IV, II, I
##     Variety = Golden Rain, Marvellous, Victory
##     rep.meas = multivariate response levels: 0, 0.2, 0.4, 0.6
# note that the multivariate levels just get treated like a factor

# I'll change "rep.meas" to "nitro"
emmeans(MOats.rlm, pairwise ~ nitro, mult.name = "nitro")
## $emmeans
##  nitro emmean   SE df lower.CL upper.CL
##  0       79.4 3.20 10     72.3     86.5
##  0.2     98.9 3.81 10     90.4    107.4
##  0.4    114.2 5.02 10    103.0    125.4
##  0.6    123.4 4.22 10    114.0    132.8
## 
## Results are averaged over the levels of: Block, Variety 
## Confidence level used: 0.95 
## 
## $contrasts
##  contrast  estimate   SE df t.ratio p.value
##  0 - 0.2     -19.50 4.22 10  -4.620 0.0044 
##  0 - 0.4     -34.83 5.71 10  -6.098 0.0006 
##  0 - 0.6     -44.00 4.31 10 -10.211 <.0001 
##  0.2 - 0.4   -15.33 5.92 10  -2.591 0.1044 
##  0.2 - 0.6   -24.50 2.85 10  -8.598 <.0001 
##  0.4 - 0.6    -9.17 5.02 10  -1.826 0.3170 
## 
## Results are averaged over the levels of: Block, Variety 
## P value adjustment: tukey method for comparing a family of 4 estimates
```