### PR TITLE
Solves rlang 0.4.0 warnings #307

### DIFF
--- a/R/helper_clean_model_data.R
+++ b/R/helper_clean_model_data.R
@@ -21,6 +21,12 @@ clean_model_data <- function(data, datargs, estimator = "") {
   m_formula <- eval_tidy(mfargs[["formula"]])
   m_formula_env <- environment(m_formula)
 
+  # From this point on we never use the environment of anything
+  # in mfargs as we always evaluate in `data` explicitly
+  # Therefore we can just change it to a list that can take
+  # expressions without environments attached to them
+  mfargs <- as.list(mfargs)
+
   args_ignored <- c("fixed_effects", "se_type")
   # For each ... that would go to model.fram .default, early eval,
   # save to formula env, and point to it


### PR DESCRIPTION
We can just follow their advice and cast `mfargs` to a list, as at a certain point we only ever evaluate elements in `mfargs` within `data`.

Please confirm this handles your warnings. I can't really test for this unless I figure out how to renew a session within a test, or create a test with a name that alphabetically comes first (and thus triggers the one warning per session warning).

Or I guess I could figure out if there's a way to always surface those warnings.

e: I just looked through how `rlang` tests these warnings and they ensure they are not on cran and then actually generate different deprecation warnings. I think we can rely on just checking warnings for now.