### PR TITLE
Starprep list

### DIFF
--- a/R/helper_starprep.R
+++ b/R/helper_starprep.R
@@ -252,14 +252,19 @@ starprep <- function(...,
 
   fits <- list(...)
 
-  gave_list <- length(fits) == 1 & is.list(fits[[1]])
+  first_object <- fits[[1]]
 
-  if(gave_list) fits <- fits[[1]]
+  gave_list <- length(fits) == 1 & is.list(first_object)
+
+  if(gave_list){
+    is_list_of_lm <- sapply(first_object, inherits, what = c("lm","lm_robust"))
+    if(all(is_list_of_lm)) fits <- first_object
+  }
 
   fitlist <- lapply(
     fits,
     function(x) {
-      if (class(x)[1] == "lm")
+      if (inherits(x, "lm"))
         commarobust(x, se_type = se_type, clusters = clusters, alpha = alpha)
       else
         x

--- a/R/helper_starprep.R
+++ b/R/helper_starprep.R
@@ -249,8 +249,15 @@ starprep <- function(...,
                      se_type = NULL,
                      clusters = NULL,
                      alpha = 0.05) {
+
+  fits <- list(...)
+
+  gave_list <- length(fits) == 1 & is.list(fits[[1]])
+
+  if(gave_list) fits <- fits[[1]]
+
   fitlist <- lapply(
-    list(...),
+    fits,
     function(x) {
       if (class(x)[1] == "lm")
         commarobust(x, se_type = se_type, clusters = clusters, alpha = alpha)

--- a/tests/testthat/test-starprep.R
+++ b/tests/testthat/test-starprep.R
@@ -248,3 +248,20 @@ test_that("Only works with lm, not mlm or glm", {
   )
 })
 
+
+test_that("starprep takes lists of fits", {
+  a <- lm(mpg ~ cyl, mtcars)
+  b <- lm(mpg ~ cyl + disp, mtcars)
+  c <- lm(mpg ~ cyl + disp + hp, mtcars)
+
+  abc <- list(a, b, c)
+  ab <- list(a, b)
+
+  expect_equal(starprep(a,b,c), starprep(abc))
+  expect_equal(starprep(a,b), starprep(ab))
+
+  })
+
+
+
+

--- a/tests/testthat/test-starprep.R
+++ b/tests/testthat/test-starprep.R
@@ -259,7 +259,18 @@ test_that("starprep takes lists of fits", {
 
   expect_equal(starprep(a,b,c), starprep(abc))
   expect_equal(starprep(a,b), starprep(ab))
+  expect_is(starprep(a), "list")
 
+  a <- lm_robust(mpg ~ cyl, mtcars)
+  b <- lm_robust(mpg ~ cyl + disp, mtcars)
+  c <- lm_robust(mpg ~ cyl + disp + hp, mtcars)
+
+  abc <- list(a, b, c)
+  ab <- list(a, b)
+
+  expect_equal(starprep(a,b,c), starprep(abc))
+  expect_equal(starprep(a,b), starprep(ab))
+  expect_is(starprep(a), "list")
   })
 
 


### PR DESCRIPTION
Thanks to @notanastronomer for the heads up on this! I've edited her MWE below a bit. 

People often like to carry around lists of lm fits, e.g. using lapply over a list of formulas. Currently, these are not handled by `starprep()`.

```
library(estimatr)
library(stargazer)
a <- lm(mpg ~ cyl, mtcars)
b <- lm(mpg ~ cyl + disp, mtcars)
c <- lm(mpg ~ cyl + disp + hp, mtcars)

abc <- list(a, b, c)
ab <- list(a, b)

# Works
starprep(a,b,c)
# Breaks
starprep(abc)
# Works
starprep(a,b)
# Breaks
starprep(ab)
```

This behavior worries me a bit, as I can see people doing something like this:

```
stargazer(a, b, se = starprep(ab), type = "text")
```

Expecting to get this:

```
stargazer(a, b, se = starprep(a,b), type = "text")
```

I've written an admittedly very quick and dirty fix in this PR, in case it's helpful to build off.

