### PR TITLE
Add n clusters to extract.lm_robust

### DIFF
--- a/R/helper_extract.R
+++ b/R/helper_extract.R
@@ -14,6 +14,7 @@
 #' @param include.nobs logical. Defaults to TRUE
 #' @param include.fstatistic logical. Defaults to TRUE
 #' @param include.rmse logical. Defaults to TRUE
+#' @param include.nclusts logical. Defaults to TRUE if clusters in \code{model}
 #' @param ... unused
 #'
 extract.robust_default <- function(model,
@@ -23,6 +24,7 @@ extract.robust_default <- function(model,
                               include.nobs = TRUE,
                               include.fstatistic = FALSE,
                               include.rmse = TRUE,
+                              include.nclusts = TRUE,
                               ...) {
   s <- tidy(model)
 
@@ -70,6 +72,12 @@ extract.robust_default <- function(model,
     gof <- c(gof, rmse)
     gof.names <- c(gof.names, "RMSE")
     gof.decimal <- c(gof.decimal, TRUE)
+  }
+  if (include.nclusts && model[["clustered"]]) {
+    rmse <- sqrt(model[["res_var"]])
+    gof <- c(gof, model[["N_clusters"]])
+    gof.names <- c(gof.names, "N Clusters")
+    gof.decimal <- c(gof.decimal, FALSE)
   }
 
   tr <- texreg::createTexreg(

--- a/tests/testthat/test-texreg.R
+++ b/tests/testthat/test-texreg.R
@@ -6,7 +6,7 @@ test_that("texreg extension works", {
 
   model2 <- lm_robust(extra~group, sleep, clusters = ID)
 
-  capture.output(treg <- extract(model2, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE))
+  capture.output(treg <- extract(model2, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE))
   expect_is(
     treg,
     "texreg"
@@ -17,5 +17,8 @@ test_that("texreg extension works", {
 
   # Remove to get SEs
   expect_true(grepl("\\(0.57\\)", texreg::texreg(model2, include.ci = FALSE)))
+
+  # Has Nclust
+  expect_true(grepl("N Clusters.*10", texreg::texreg(model2)))
 
 })


### PR DESCRIPTION
While `extract.lm_robust` is gross, it looks like the other extract functions. So until such a time it gets completely re-written, I'm just going to add features as in this PR, where I add the ability to include the number of clusters for clustered designs.