### PR TITLE
Early check for formula type, closes #349

### DIFF
--- a/R/helper_clean_model_data.R
+++ b/R/helper_clean_model_data.R
@@ -21,6 +21,8 @@ clean_model_data <- function(data, datargs, estimator = "") {
   m_formula <- eval_tidy(mfargs[["formula"]])
   m_formula_env <- environment(m_formula)
 
+  stopifnot("`formula` argument must be a formula"=inherits(m_formula, "formula"))
+
   # From this point on we never use the environment of anything
   # in mfargs as we always evaluate in `data` explicitly
   # Therefore we can just change it to a list that can take

--- a/tests/testthat/test-arg-checking.R
+++ b/tests/testthat/test-arg-checking.R
@@ -1,0 +1,12 @@
+context("Estimator - Arg checking fails as expected.")
+
+test_that("#349 Early fail when formula is a string", {
+  expect_error(
+    estimatr::lm_robust("mpg~hp", data = mtcars, cluster = wt),
+    "formula"
+  )
+  expect_length(
+    estimatr::lm_robust(mpg~hp, data = mtcars, cluster = wt),
+    29
+  )
+})


### PR DESCRIPTION
Early check for formula type, closes #349

Use R 4.0 style labeled stopifnot, but backwards compatible.