### PR TITLE
new tidy arguments: conf.int & conf.level

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     rlang (>= 0.2.0)
 LinkingTo: Rcpp, RcppEigen
 Encoding: UTF-8
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 LazyData: true
 Suggests:
     fabricatr (>= 0.10.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# estimatr 0.23.0
+
+* tidy: rename nobs, nclusters, nblocks
+* tidy: new arguments conf.int, conf.level
+
 # estimatr 0.22.0 
 
 * Bug fixes

--- a/R/S3_tidy.R
+++ b/R/S3_tidy.R
@@ -29,14 +29,15 @@ tidy_data_frame <- function(x,
   rownames(return_frame) <- NULL
 
   # re-calculate CIs if explicitly requested and alpha level has changed
-  flag <- conf.int && utils::hasName(x, 'alpha') && (1 - x$alpha != conf.level)
+  # x$alpha[1] because lm_robust duplicates alpha with multiple linear_hypotheses
+  flag <- conf.int || (utils::hasName(x, 'alpha') && (1 - x$alpha[1] != conf.level))
   if (flag) {
       ci <- stats::confint(x, level = conf.level, ...)
       if (all(row.names(ci) == return_frame$term))  {
           return_frame$conf.low <- ci[, 1]
           return_frame$conf.high <- ci[, 2]
       }
-  }               
+  }
 
 
   return(return_frame)

--- a/R/S3_tidy.R
+++ b/R/S3_tidy.R
@@ -31,13 +31,13 @@ tidy_data_frame <- function(x,
   # re-calculate CIs if explicitly requested and alpha level has changed
   flag <- conf.int && utils::hasName(x, 'alpha') && (1 - x$alpha != conf.level)
   if (flag) {
-      ci <- tryCatch(stats::confint(x, level = conf.level), error = function(e) NULL)
-      flag <- inherits(ci, 'matrix') && all(row.names(ci) == return_frame$term)
-      if (flag) {
+      ci <- stats::confint(x, level = conf.level, ...)
+      if (all(row.names(ci) == return_frame$term))  {
           return_frame$conf.low <- ci[, 1]
           return_frame$conf.high <- ci[, 2]
       }
   }               
+
 
   return(return_frame)
 }
@@ -78,7 +78,7 @@ tidy.lm_robust <- function(x,
                            conf.level = .95,
                            ...) {
   warn_singularities(x)
-  tidy_data_frame(x, conf.int = conf.int, conf.level = conf.level)
+  tidy_data_frame(x, conf.int = conf.int, conf.level = conf.level, ...)
 }
 
 #' @rdname estimatr_tidiers
@@ -88,7 +88,7 @@ tidy.lm_robust <- function(x,
 #' @family estimatr tidiers
 tidy.iv_robust <- function(x, conf.int = FALSE, conf.level = .95, ...) {
   warn_singularities(x)
-  tidy_data_frame(x, conf.int = conf.int, conf.level = conf.level)
+  tidy_data_frame(x, conf.int = conf.int, conf.level = conf.level, ...)
 }
 
 #' @rdname estimatr_tidiers
@@ -105,14 +105,13 @@ tidy.difference_in_means <- tidy_data_frame
 #' @family estimatr tidiers
 tidy.horvitz_thompson <- tidy_data_frame
 
-
 #' @rdname estimatr_tidiers
 #' @templateVar class lh_robust
 #'
 #' @export
 #' @family estimatr tidiers
 tidy.lh_robust <- function(x, ...) {
-  rbind(tidy(x$lm_robust), tidy(x$lh))
+  rbind(tidy(x$lm_robust, ...), tidy(x$lh, ...))
 }
 
 #' @rdname estimatr_tidiers
@@ -121,7 +120,7 @@ tidy.lh_robust <- function(x, ...) {
 #' @export
 #' @family estimatr tidiers
 tidy.lh <- function(x, ...) {
-  tidy_data_frame(simplify_lh_outcome(x))
+  tidy_data_frame(simplify_lh_outcome(x), ...)
 }
 
 # Simplifies the `lh` outcome column for tidy.lh and print.lh

--- a/R/S3_tidy.R
+++ b/R/S3_tidy.R
@@ -2,7 +2,10 @@
 #' @export
 generics::tidy
 
-tidy_data_frame <- function(x, ...) {
+tidy_data_frame <- function(x, 
+                            conf.int = FALSE,
+                            conf.level = .95,
+                            ...) {
   vec_cols <- c(
     "coefficients",
     "std.error",
@@ -24,6 +27,17 @@ tidy_data_frame <- function(x, ...) {
   )
 
   rownames(return_frame) <- NULL
+
+  # re-calculate CIs if explicitly requested and alpha level has changed
+  flag <- conf.int && utils::hasName(x, 'alpha') && (1 - x$alpha != conf.level)
+  if (flag) {
+      ci <- tryCatch(stats::confint(x, level = conf.level), error = function(e) NULL)
+      flag <- inherits(ci, 'matrix') && all(row.names(ci) == return_frame$term)
+      if (flag) {
+          return_frame$conf.low <- ci[, 1]
+          return_frame$conf.high <- ci[, 2]
+      }
+  }               
 
   return(return_frame)
 }
@@ -47,15 +61,24 @@ warn_singularities <- function(x) {
 #' name of the outcome variable
 #'
 #' @param x An object returned by one of the estimators
+#' @param conf.int  Logical indicating whether or not to include a
+#'   confidence interval in the tidied output. Defaults to ‘FALSE’.
+#' @param conf.level  The confidence level to use for the confidence
+#'   interval if ‘conf.int = TRUE’. Must be strictly greater than 0 and less
+#'   than 1. Defaults to 0.95, which corresponds to a 95 percent confidence
+#'   interval.
 #' @param ... extra arguments (not used)
 #'
 #' @export
 #' @family estimatr tidiers
 #' @seealso [generics::tidy()], [estimatr::lm_robust()], [estimatr::iv_robust()],  [estimatr::difference_in_means()], [estimatr::horvitz_thompson()]
 #' @md
-tidy.lm_robust <- function(x, ...) {
+tidy.lm_robust <- function(x,
+                           conf.int = FALSE,
+                           conf.level = .95,
+                           ...) {
   warn_singularities(x)
-  tidy_data_frame(x)
+  tidy_data_frame(x, conf.int = conf.int, conf.level = conf.level)
 }
 
 #' @rdname estimatr_tidiers
@@ -63,9 +86,9 @@ tidy.lm_robust <- function(x, ...) {
 #'
 #' @export
 #' @family estimatr tidiers
-tidy.iv_robust <- function(x, ...) {
+tidy.iv_robust <- function(x, conf.int = FALSE, conf.level = .95, ...) {
   warn_singularities(x)
-  tidy_data_frame(x)
+  tidy_data_frame(x, conf.int = conf.int, conf.level = conf.level)
 }
 
 #' @rdname estimatr_tidiers

--- a/R/S3_vcov.R
+++ b/R/S3_vcov.R
@@ -4,20 +4,15 @@ vcov.lm_robust <- function(object, complete = TRUE, ...) {
 }
 
 #' @export
-vcov.iv_robust <- function(object, complete = TRUE, ...) {
-  vcov_simple(object, complete = complete)
+vcov.iv_robust <- vcov.lm_robust
+
+#' @export
+vcov.difference_in_means <- function(object, ...) {
+  return(object$vcov)
 }
 
 #' @export
-vcov.difference_in_means <- function(object, complete = TRUE, ...) {
-  stop("vcov not supported for difference_in_means")
-}
-
-
-#' @export
-vcov.horvitz_thompson <- function(object, complete = TRUE, ...) {
-  stop("vcov not supported for horvitz_thompson")
-}
+vcov.horvitz_thompson <- vcov.difference_in_means
 
 
 # Helper function for extracting vcov when it is just an element in the object list

--- a/R/helper_return.R
+++ b/R/helper_return.R
@@ -79,5 +79,10 @@ dim_like_return <- function(return_list, alpha, formula, conditions) {
   return_list[["condition2"]] <- conditions[[2]]
   return_list[["condition1"]] <- conditions[[1]]
 
+  return_list[["vcov"]] <- matrix(
+    data = return_list[["std.error"]] ^ 2,
+    dimnames = list(return_list[["term"]], return_list[["term"]])
+  )
+
   return(return_list)
 }

--- a/man/estimatr_glancers.Rd
+++ b/man/estimatr_glancers.Rd
@@ -73,6 +73,6 @@ For \code{glance.horvitz_thompson}, a data.frame with columns:
 Glance at an estimatr object
 }
 \seealso{
-\code{\link[generics:glance]{generics::glance()}}, \code{\link[estimatr:lm_robust]{estimatr::lm_robust()}}, \code{\link[estimatr:lm_lin]{estimatr::lm_lin()}}, \code{\link[estimatr:iv_robust]{estimatr::iv_robust()}}, \code{\link[estimatr:difference_in_means]{estimatr::difference_in_means()}}, \code{\link[estimatr:horvitz_thompson]{estimatr::horvitz_thompson()}}
+\code{\link[generics:glance]{generics::glance()}}, \code{\link[=lm_robust]{lm_robust()}}, \code{\link[=lm_lin]{lm_lin()}}, \code{\link[=iv_robust]{iv_robust()}}, \code{\link[=difference_in_means]{difference_in_means()}}, \code{\link[=horvitz_thompson]{horvitz_thompson()}}
 }
 \concept{estimatr glancers}

--- a/man/estimatr_glancers.Rd
+++ b/man/estimatr_glancers.Rd
@@ -73,6 +73,6 @@ For \code{glance.horvitz_thompson}, a data.frame with columns:
 Glance at an estimatr object
 }
 \seealso{
-\code{\link[generics:glance]{generics::glance()}}, \code{\link[=lm_robust]{lm_robust()}}, \code{\link[=lm_lin]{lm_lin()}}, \code{\link[=iv_robust]{iv_robust()}}, \code{\link[=difference_in_means]{difference_in_means()}}, \code{\link[=horvitz_thompson]{horvitz_thompson()}}
+\code{\link[generics:glance]{generics::glance()}}, \code{\link[estimatr:lm_robust]{estimatr::lm_robust()}}, \code{\link[estimatr:lm_lin]{estimatr::lm_lin()}}, \code{\link[estimatr:iv_robust]{estimatr::iv_robust()}}, \code{\link[estimatr:difference_in_means]{estimatr::difference_in_means()}}, \code{\link[estimatr:horvitz_thompson]{estimatr::horvitz_thompson()}}
 }
 \concept{estimatr glancers}

--- a/man/estimatr_tidiers.Rd
+++ b/man/estimatr_tidiers.Rd
@@ -10,13 +10,13 @@
 \alias{tidy.lh}
 \title{Tidy an estimatr object}
 \usage{
-\method{tidy}{lm_robust}(x, ...)
+\method{tidy}{lm_robust}(x, conf.int = FALSE, conf.level = 0.95, ...)
 
-\method{tidy}{iv_robust}(x, ...)
+\method{tidy}{iv_robust}(x, conf.int = FALSE, conf.level = 0.95, ...)
 
-\method{tidy}{difference_in_means}(x, ...)
+\method{tidy}{difference_in_means}(x, conf.int = FALSE, conf.level = 0.95, ...)
 
-\method{tidy}{horvitz_thompson}(x, ...)
+\method{tidy}{horvitz_thompson}(x, conf.int = FALSE, conf.level = 0.95, ...)
 
 \method{tidy}{lh_robust}(x, ...)
 
@@ -24,6 +24,14 @@
 }
 \arguments{
 \item{x}{An object returned by one of the estimators}
+
+\item{conf.int}{Logical indicating whether or not to include a
+confidence interval in the tidied output. Defaults to ‘FALSE’.}
+
+\item{conf.level}{The confidence level to use for the confidence
+interval if ‘conf.int = TRUE’. Must be strictly greater than 0 and less
+than 1. Defaults to 0.95, which corresponds to a 95 percent confidence
+interval.}
 
 \item{...}{extra arguments (not used)}
 }
@@ -36,6 +44,6 @@ name of the outcome variable
 Tidy an estimatr object
 }
 \seealso{
-\code{\link[generics:tidy]{generics::tidy()}}, \code{\link[estimatr:lm_robust]{estimatr::lm_robust()}}, \code{\link[estimatr:iv_robust]{estimatr::iv_robust()}},  \code{\link[estimatr:difference_in_means]{estimatr::difference_in_means()}}, \code{\link[estimatr:horvitz_thompson]{estimatr::horvitz_thompson()}}
+\code{\link[generics:tidy]{generics::tidy()}}, \code{\link[=lm_robust]{lm_robust()}}, \code{\link[=iv_robust]{iv_robust()}},  \code{\link[=difference_in_means]{difference_in_means()}}, \code{\link[=horvitz_thompson]{horvitz_thompson()}}
 }
 \concept{estimatr tidiers}

--- a/man/estimatr_tidiers.Rd
+++ b/man/estimatr_tidiers.Rd
@@ -44,6 +44,6 @@ name of the outcome variable
 Tidy an estimatr object
 }
 \seealso{
-\code{\link[generics:tidy]{generics::tidy()}}, \code{\link[estimatr:lm_robust]{estimatr::lm_robust()}}, \code{\link[estimatr:iv_robust]{estimatr::iv_robust()}},  \code{\link[estimatr:difference_in_means]{estimatr::difference_in_means()}}, \code{\link[estimatr:horvitz_thompson]{estimatr::horvitz_thompson()}}
+\code{\link[generics:tidy]{generics::tidy()}}, \code{\link[=lm_robust]{lm_robust()}}, \code{\link[=iv_robust]{iv_robust()}},  \code{\link[=difference_in_means]{difference_in_means()}}, \code{\link[=horvitz_thompson]{horvitz_thompson()}}
 }
 \concept{estimatr tidiers}

--- a/man/estimatr_tidiers.Rd
+++ b/man/estimatr_tidiers.Rd
@@ -44,6 +44,6 @@ name of the outcome variable
 Tidy an estimatr object
 }
 \seealso{
-\code{\link[generics:tidy]{generics::tidy()}}, \code{\link[=lm_robust]{lm_robust()}}, \code{\link[=iv_robust]{iv_robust()}},  \code{\link[=difference_in_means]{difference_in_means()}}, \code{\link[=horvitz_thompson]{horvitz_thompson()}}
+\code{\link[generics:tidy]{generics::tidy()}}, \code{\link[estimatr:lm_robust]{estimatr::lm_robust()}}, \code{\link[estimatr:iv_robust]{estimatr::iv_robust()}},  \code{\link[estimatr:difference_in_means]{estimatr::difference_in_means()}}, \code{\link[estimatr:horvitz_thompson]{estimatr::horvitz_thompson()}}
 }
 \concept{estimatr tidiers}

--- a/tests/testthat/test-s3-methods.R
+++ b/tests/testthat/test-s3-methods.R
@@ -345,15 +345,16 @@ test_that("vcov works", {
     "return_vcov = TRUE"
   )
 
-  expect_error(
-    vcov(horvitz_thompson(y ~ x, condition_prs = p, data = dat)),
-    "supported|horvitz_thompson"
+  hto <- horvitz_thompson(y ~ x, condition_prs = p, data = dat)
+  expect_equal(
+    vcov(hto),
+    matrix(hto$std.error ^ 2, dimnames = list(hto$term, hto$term))
   )
 
-
-  expect_error(
-    vcov(difference_in_means(y ~ x, data = dat)),
-    "supported|difference_in_means"
+  dimo <- difference_in_means(y ~ x, data = dat)
+  expect_equal(
+    vcov(dimo),
+    matrix(dimo$std.error ^ 2, dimnames = list(dimo$term, dimo$term))
   )
 
   # Instrumental variables
@@ -994,11 +995,32 @@ test_that("tidy conf_level", {
 
     mod <- lm_robust(mpg ~ hp + factor(cyl) + gear, mtcars)
 
-    expect_equal(unname(confint(mod, level = .95)[, 1]), 
+    expect_equal(unname(confint(mod, level = .95)[, 1]),
                  tidy(mod)$conf.low)
 
-    expect_equal(unname(confint(mod, level = .999)[, 1]), 
+    expect_equal(unname(confint(mod, level = .999)[, 1]),
                  tidy(mod, conf.int = TRUE, conf.level = .999)$conf.low)
 
+    dimmod <- difference_in_means(mpg ~ am, mtcars)
+
+    expect_equal(
+      unname(confint(dimmod, level = .999)[, 1]),
+      tidy(dimmod, conf.int = TRUE, conf.level = .999)$conf.low
+    )
+
+    expect_false(
+      tidy(dimmod, conf.int = TRUE, conf.level = .999)$conf.low == tidy(dimmod)$conf.low
+    )
+
+    htmod <- horvitz_thompson(mpg ~ am, mtcars, condition_prs = 0.5)
+
+    expect_equal(
+      unname(confint(htmod, level = .999)[, 1]),
+      tidy(htmod, conf.int = TRUE, conf.level = .999)$conf.low
+    )
+
+    expect_false(
+      tidy(htmod, conf.int = TRUE, conf.level = .999)$conf.low == tidy(htmod)$conf.low
+    )
 
 })

--- a/tests/testthat/test-s3-methods.R
+++ b/tests/testthat/test-s3-methods.R
@@ -994,10 +994,11 @@ test_that("tidy conf_level", {
 
     mod <- lm_robust(mpg ~ hp + factor(cyl) + gear, mtcars)
 
-    truth  <- c(13.9946994508471, -0.0879182720503278, -6.78499264035586, -7.57127120766524, 1.11960081760074)
-    expect_equal(truth, tidy(mod)$conf.low)
+    expect_equal(unname(confint(mod, level = .95)[, 1]), 
+                 tidy(mod)$conf.low)
 
-    truth  <- c(9.35879901429946, -0.11386438606093, -8.95208521114944, -11.7803907124633, -0.218853284108813)
-    expect_equal(truth, tidy(mod, conf.int = TRUE, conf.level = .999)$conf.low)
+    expect_equal(unname(confint(mod, level = .999)[, 1]), 
+                 tidy(mod, conf.int = TRUE, conf.level = .999)$conf.low)
+
 
 })

--- a/tests/testthat/test-s3-methods.R
+++ b/tests/testthat/test-s3-methods.R
@@ -989,3 +989,15 @@ test_that("predict.iv_robust works with fixed effects", {
   )
 
 })
+
+test_that("tidy conf_level", {
+
+    mod <- lm_robust(mpg ~ hp + factor(cyl) + gear, mtcars)
+
+    truth  <- c(13.9946994508471, -0.0879182720503278, -6.78499264035586, -7.57127120766524, 1.11960081760074)
+    expect_equal(truth, tidy(mod)$conf.low)
+
+    truth  <- c(9.35879901429946, -0.11386438606093, -8.95208521114944, -11.7803907124633, -0.218853284108813)
+    expect_equal(truth, tidy(mod, conf.int = TRUE, conf.level = .999)$conf.low)
+
+})


### PR DESCRIPTION
The `tidy` methods packaged with `broom` and `broom.mixed` include two arguments that are currently unsupported by `estimatr`: `conf.int` and `conf.level`. 

I ran into this problem when using `modelsummary`, a package which extracts information from models using `tidy`. This code produces a regression table and a coefficients plot, but the confidence intervals are incorrect, because `estimatr::tidy` ignores arguments that standard `tidy` methods accept:

```r
library(modelsummary)
library(estimatr)
mod <- lm_robust(mpg ~ hp + factor(cyl), mtcars)

modelsummary(mod, statistic = 'conf.int', conf_level = .99)

modelplot(mod, statistic = 'conf.int', conf_level = .99)
```

This is especially problematic because `estimatr::tidy` accepts the ellipsis, which means we can pass `conf.level=.99` and it will still return alpha=.05 without a warning.

This PR adds the missing arguments, and re-calculates CIs if the alpha level requested by `tidy` does not match the alpha level requested in the initial call to `lm_robust` et al.