### PR TITLE
Fix fixed_effects failing to converge with large numbers

### DIFF
--- a/src/lm_robust_helper.cpp
+++ b/src/lm_robust_helper.cpp
@@ -17,8 +17,10 @@ Eigen::ArrayXXd demeanMat2(const Eigen::MatrixXd& what,
 
   Eigen::ArrayXXd out(n,p);
   Eigen::ArrayXd oldcol(n);
+  double norm2 = 0.0;
+  double neweps = 0.0;
 
-  out =  what.block(0, start_col, n , p);
+  out =  what.block(0, start_col, n, p);
 
   int nlevels = max(fes) + 1; // add one because factor codes are 1:N
   Eigen::ArrayXd group_sums(nlevels);
@@ -32,11 +34,15 @@ Eigen::ArrayXXd demeanMat2(const Eigen::MatrixXd& what,
     }
   }
 
-
-
   for (int k=0; k<p; k++) {
 
-    double delta = 9999;
+    // Adjust eps to allow for numerically large covariates to converge
+    for (int i=0; i<n; i++) {
+      norm2 += out(i, k) * out(i, k);
+    }
+    neweps = 0.01 * eps * norm2;
+
+    double delta = 0.0;
 
     do {
       oldcol = out.col(k);
@@ -58,20 +64,16 @@ Eigen::ArrayXXd demeanMat2(const Eigen::MatrixXd& what,
 
       }
 
-      delta = std::sqrt((oldcol - out.col(k)).pow(2).sum());
+      delta = 0.0;
+      neweps = 0.0;
+      for (int i=0; i<n; i++) {
+        delta += (oldcol(i, k) - out(i, k)) * (oldcol(i, k) - out(i, k));
+        neweps += out(i, k) * out(i, k);
+      }
+      delta = std::sqrt(delta);
+      neweps = sqrt(1.0 + neweps) * eps *  0.01;
 
-
-      // Rcout << delta << std::endl;
-      // Rcout << "**********************************" << std::endl;
-      // Rcout << group_sums << std::endl;
-      // Rcout << "**********************************" << std::endl;
-      // Rcout << "old" << oldcol << std::endl;
-      // Rcout << "**********************************" << std::endl;
-      // Rcout << "outk" << out.col(k) << std::endl;
-      // Rcout << "**********************************" << std::endl;
-      // return out;
-
-    } while (delta >= eps);
+    } while ((delta >= neweps));
 
   }
 

--- a/src/lm_robust_helper.cpp
+++ b/src/lm_robust_helper.cpp
@@ -73,7 +73,7 @@ Eigen::ArrayXXd demeanMat2(const Eigen::MatrixXd& what,
       delta = std::sqrt(delta);
       neweps = sqrt(1.0 + neweps) * eps *  0.01;
 
-    } while ((delta >= neweps));
+    } while (delta >= neweps);
 
   }
 

--- a/tests/testthat/test-lm-robust-fes.R
+++ b/tests/testthat/test-lm-robust-fes.R
@@ -385,6 +385,9 @@ test_that("FEs handle collinear FEs", {
 
 test_that("FEs work with collinear covariates", {
   ## Classical
+
+  sum(dat$X^2) * 1e-4 * 1e-8
+  sum(dat$Xdup^2)
   for (se_type in se_types) {
     ro <- tidy(lm_robust(Y ~ Z + X + Xdup + factor(B) + factor(B2), data = dat, se_type = se_type))
     rfo <- tidy(lm_robust(Y ~ Z + X + Xdup, fixed_effects = ~ B + B2, data = dat, se_type = se_type))
@@ -672,6 +675,23 @@ test_that("FEs handle collinear covariates", {
       tidy(lmfo)[grepl("cyl", lmfo$term), ]
     )
   }
+
+})
+
+test_that("FEs handle large numbers", {
+  df <- data.frame(
+    i = rep(1:100,100),
+    x = rnorm(10000) * 1000000 + 10000000,
+    y = rnorm(10000)
+  )
+
+  fefit <- tidy(lm_robust(y ~ x, data = df, fixed_effects = ~i, se_type = "HC1"))
+  lmfit <- tidy(lm_robust(y ~ x - 1 + factor(i), data = df, se_type = "HC1"))
+
+  expect_equal(
+    fefit[fefit$term == "x", ],
+    lmfit[lmfit$term == "x", ],
+  )
 
 })
 


### PR DESCRIPTION
The target for demeaning for fixed effects now scales with the scale of the covariate being demeaned, much like `lfe` does.

Closes #312 