### PR TITLE
Prep for CRAN submission v0.24

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: estimatr
 Type: Package
 Title: Fast Estimators for Design-Based Inference
-Version: 0.22.0
+Version: 0.24.0
 Authors@R: c(person("Graeme", "Blair", email = "graeme.blair@ucla.edu", role = c("aut", "cre")),
              person("Jasper", "Cooper", email = "jjc2247@columbia.edu", role = c("aut")),
              person("Alexander", "Coppock", email = "alex.coppock@yale.edu", role = c("aut")),
@@ -14,7 +14,7 @@ Description: Fast procedures for small set of commonly-used, design-appropriate 
 URL: https://declaredesign.org/r/estimatr/, https://github.com/DeclareDesign/estimatr
 BugReports: https://github.com/DeclareDesign/estimatr/issues
 License: MIT + file LICENSE
-Depends: R (>= 3.5.0)
+Depends: R (>= 3.6.0)
 Imports:
     Formula,
     generics,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
-# estimatr 0.23.0
+# estimatr 0.24.0
 
 * tidy: rename nobs, nclusters, nblocks
 * tidy: new arguments conf.int, conf.level
+* Added `update.iv_robust()`
+* Bug fix regarding fixed effects with large numbers
 
 # estimatr 0.22.0 
 


### PR DESCRIPTION
Update news and description (key change = require R 3.6 as 3.5 is no longer "old").